### PR TITLE
feat(jwt): serialize tokens, fixes #13

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ val sub = idToken.claims.sub
 Custom attributes of the IdToken get mapped into `customAttributes`
 
 ```kotlin
-val twitter = idToken.claims.customAttributes["twitter"]
+val twitter = idToken.claims.customAttributes["custom:twitter"]
 ```
 
 #### Get User

--- a/README.md
+++ b/README.md
@@ -95,6 +95,25 @@ At the moment you can only sign in with username and password.
 signIn(username = "USERNAME", password = "PASSWORD"): Result<SignInResponse>
 ```
 
+#### Get Claims
+
+You can retrieve the claims of both the IdTokens' and AccessTokens' payload by converting them to either a `CognitoIdToken` or `CognitoAccessToken`
+
+```kotlin
+val idToken = CognitoIdToken(idTokenString)
+// or
+val accessToken = CognitoAccessToken(accessTokenString)
+
+val phoneNumber = idToken.claims.phoneNumber
+val sub = idToken.claims.sub
+```
+
+Custom attributes of the IdToken get mapped into `customAttributes`
+
+```kotlin
+val twitter = idToken.claims.customAttributes["twitter"]
+```
+
 #### Get User
 
 Returns the users attributes and metadata on success.
@@ -103,16 +122,6 @@ More info about this in the [official documentation](https://docs.aws.amazon.com
 
 ```kotlin
 getUser(accessToken = "TOKEN_FROM_SIGN_IN_REQUEST"): Result<GetUserResponse>
-```
-
-#### Get Claims
-
-Parses the ID token to a Claims object (e.g. to access the sub id or email address). 
-
-> Not generic, refer to the Claims class to see which parameters are supported.
-
-```kotlin
-getClaims(fromIdToken = "ID_TOKEN_FROM_SIGN_IN_REQUEST"): Result<Claims>
 ```
 
 #### Update User Attributes

--- a/auth/src/androidMain/kotlin/com/liftric/auth/jwt/Base64.kt
+++ b/auth/src/androidMain/kotlin/com/liftric/auth/jwt/Base64.kt
@@ -1,11 +1,16 @@
 package com.liftric.auth.jwt
 
 import android.util.Base64
+import java.io.UnsupportedEncodingException
 
 internal actual class Base64 {
     actual companion object {
         actual fun decode(string: String): String? {
-            return String(Base64.decode(string, Base64.URL_SAFE),  Charsets.UTF_8)
+            return try {
+                String(Base64.decode(string, Base64.URL_SAFE), Charsets.UTF_8)
+            } catch (e: Exception) {
+                null
+            }
         }
     }
 }

--- a/auth/src/androidMain/kotlin/com/liftric/auth/jwt/Base64.kt
+++ b/auth/src/androidMain/kotlin/com/liftric/auth/jwt/Base64.kt
@@ -1,4 +1,4 @@
-package com.liftric.auth.base
+package com.liftric.auth.jwt
 
 import android.util.Base64
 

--- a/auth/src/commonMain/kotlin/com/liftric/auth/Auth.kt
+++ b/auth/src/commonMain/kotlin/com/liftric/auth/Auth.kt
@@ -1,6 +1,10 @@
 package com.liftric.auth
 
 import com.liftric.auth.base.*
+import com.liftric.auth.jwt.Base64
+import com.liftric.auth.jwt.CognitoAccessToken
+import com.liftric.auth.jwt.CognitoIdToken
+import kotlinx.serialization.json.Json
 
 interface Auth {
     /**
@@ -102,9 +106,16 @@ interface Auth {
     suspend fun deleteUser(accessToken: String): Result<Unit>
 
     /**
-     * Parses the id token and returns the claims (Not all claims implemented!)
+     * Parses the id token string to an actual object. Custom attributes are accessible via the 'custom' map as String value.
      * @param fromIdToken The id token from the sign in request
-     * @return Result object containing Claims on success or an error on failure
+     * @return Result object containing CognitoIdToken on success or an error on failure
      */
-    fun getClaims(fromIdToken: String): Result<Claims>
+    fun idTokenPayload(fromIdToken: String): Result<CognitoIdToken>
+
+    /**
+     * Parses the access token string to an actual object
+     * @param fromAccessToken The id token from the sign in request
+     * @return Result object containing CognitoAccessToken on success or an error on failure
+     */
+    fun accessTokenPayload(fromAccessToken: String): Result<CognitoAccessToken>
 }

--- a/auth/src/commonMain/kotlin/com/liftric/auth/Auth.kt
+++ b/auth/src/commonMain/kotlin/com/liftric/auth/Auth.kt
@@ -104,18 +104,4 @@ interface Auth {
      * @return Result object containing Unit on success or an error on failure
      */
     suspend fun deleteUser(accessToken: String): Result<Unit>
-
-    /**
-     * Parses the id token string to an actual object. Custom attributes are accessible via the 'custom' map as String value.
-     * @param fromIdToken The id token from the sign in request
-     * @return Result object containing CognitoIdToken on success or an error on failure
-     */
-    fun idTokenPayload(fromIdToken: String): Result<CognitoIdToken>
-
-    /**
-     * Parses the access token string to an actual object
-     * @param fromAccessToken The id token from the sign in request
-     * @return Result object containing CognitoAccessToken on success or an error on failure
-     */
-    fun accessTokenPayload(fromAccessToken: String): Result<CognitoAccessToken>
 }

--- a/auth/src/commonMain/kotlin/com/liftric/auth/AuthHandler.kt
+++ b/auth/src/commonMain/kotlin/com/liftric/auth/AuthHandler.kt
@@ -265,38 +265,6 @@ open class AuthHandler(private val configuration: Configuration) : Auth {
         }
     }
 
-    override fun idTokenPayload(fromIdToken: String): Result<CognitoIdToken> {
-        return try {
-            val component = fromIdToken.split(".")[1]
-            Base64.decode(component)?.let { decoded64 ->
-                val json = Json {  isLenient = true }
-                json.decodeFromString(CognitoIdToken.serializer(), decoded64)?.let { token ->
-                    Result.success(token)
-                }
-            }?: run {
-                Result.failure(Error("Couldn't decode id token"))
-            }
-        } catch (e: Exception) {
-            Result.failure(e)
-        }
-    }
-
-    override fun accessTokenPayload(fromAccessToken: String): Result<CognitoAccessToken> {
-        return try {
-            val component = fromAccessToken.split(".")[1]
-            Base64.decode(component)?.let { decoded64 ->
-                val json = Json {  isLenient = true }
-                json.decodeFromString(CognitoAccessToken.serializer(), decoded64)?.let { token ->
-                    Result.success(token)
-                }
-            }?: run {
-                Result.failure(Error("Couldn't decode access token"))
-            }
-        } catch (e: Exception) {
-            Result.failure(e)
-        }
-    }
-
     //----------
     // REQUEST
     //----------

--- a/auth/src/commonMain/kotlin/com/liftric/auth/base/Response.kt
+++ b/auth/src/commonMain/kotlin/com/liftric/auth/base/Response.kt
@@ -64,25 +64,3 @@ data class GetAttributeVerificationCodeResponse(
 data class ForgotPasswordResponse(
     val CodeDeliveryDetails: CodeDeliveryDetails = CodeDeliveryDetails()
 )
-
-@Serializable
-data class Claims(
-    val sub: String,
-    val aud: String,
-    @SerialName("cognito:groups")
-    val cognitoGroups: List<String>,
-    @SerialName("email_verified")
-    val emailVerified: Boolean? = null,
-    @SerialName("event_id")
-    val eventId: String,
-    @SerialName("token_use")
-    val tokenUse: String,
-    @SerialName("auth_time")
-    val authTime: String,
-    val iss: String,
-    @SerialName("cognito:username")
-    val cognitoUsername: String,
-    val exp: String,
-    val iat: String,
-    val email: String? = null
-)

--- a/auth/src/commonMain/kotlin/com/liftric/auth/jwt/AccessToken.kt
+++ b/auth/src/commonMain/kotlin/com/liftric/auth/jwt/AccessToken.kt
@@ -13,3 +13,16 @@ interface AccessToken {
     val nbf: Long
     val sub: String
 }
+
+interface AccessTokenExtenstion {
+    val authTime: Long
+    val clientId: String
+    val cognitoGroups: List<String>
+    val deviceKey: String
+    val email: String
+    val emailVerified: Boolean
+    val eventId: String
+    val scope: String
+    val tokenUse: String
+    val username: String
+}

--- a/auth/src/commonMain/kotlin/com/liftric/auth/jwt/AccessToken.kt
+++ b/auth/src/commonMain/kotlin/com/liftric/auth/jwt/AccessToken.kt
@@ -1,0 +1,15 @@
+package com.liftric.auth.jwt
+
+/**
+ * Access Token containing claims specified by IETF:
+ * https://tools.ietf.org/html/rfc7519#section-4
+ */
+interface AccessToken {
+    val aud: String
+    val exp: Long
+    val iat: Long
+    val iss: String
+    val jti: String
+    val nbf: Long
+    val sub: String
+}

--- a/auth/src/commonMain/kotlin/com/liftric/auth/jwt/AccessToken.kt
+++ b/auth/src/commonMain/kotlin/com/liftric/auth/jwt/AccessToken.kt
@@ -5,24 +5,83 @@ package com.liftric.auth.jwt
  * https://tools.ietf.org/html/rfc7519#section-4
  */
 interface AccessToken {
-    val aud: String
+    /**
+     * Audience
+     */
+    val aud: String?
+
+    /**
+     * Expiration Time
+     */
     val exp: Long
+
+    /**
+     * Issued at
+     */
     val iat: Long
+
+    /**
+     * Issuer
+     */
     val iss: String
+
+    /**
+     * JWT ID
+     */
     val jti: String
-    val nbf: Long
+
+    /**
+     * Not Before
+     */
+    val nbf: Long?
+
+    /**
+     * Subject
+     */
     val sub: String
 }
 
-interface AccessTokenExtenstion {
+/**
+ * Access Token extension for Cognito
+ */
+interface AccessTokenExtension {
+    /**
+     * Time when the authentication occurred. JSON number that represents the number of seconds from 1970-01-01T0:0:0Z as measured in UTC format
+     */
     val authTime: Long
+
+    /**
+     * Client id
+     */
     val clientId: String
+
+    /**
+     * List of groups the user belongs to
+     */
     val cognitoGroups: List<String>
-    val deviceKey: String
-    val email: String
-    val emailVerified: Boolean
-    val eventId: String
-    val scope: String
+
+    /**
+     * Device key
+     */
+    val deviceKey: String?
+
+    /**
+     * Event id
+     */
+    val eventId: String?
+
+    /**
+     * List of Oauth 2.0 scopes that define what access the token provides
+     */
+    val scope: String?
+
+    /**
+     * Intended purpose of this token. Its value is always access
+     */
     val tokenUse: String
+
+    /**
+     * Username
+     */
     val username: String
 }

--- a/auth/src/commonMain/kotlin/com/liftric/auth/jwt/Base64.kt
+++ b/auth/src/commonMain/kotlin/com/liftric/auth/jwt/Base64.kt
@@ -1,4 +1,4 @@
-package com.liftric.auth.base
+package com.liftric.auth.jwt
 
 internal expect class Base64 {
     companion object {

--- a/auth/src/commonMain/kotlin/com/liftric/auth/jwt/CognitoAccessToken.kt
+++ b/auth/src/commonMain/kotlin/com/liftric/auth/jwt/CognitoAccessToken.kt
@@ -8,12 +8,12 @@ class InvalidCognitoAccessTokenException(message:String): Exception(message)
 
 @Serializable
 data class CognitoAccessTokenClaims(
-    override val aud: String,
+    override val aud: String? = null,
     override val exp: Long,
     override val iat: Long,
     override val iss: String,
     override val jti: String,
-    override val nbf: Long,
+    override val nbf: Long? = null,
     override val sub: String,
     @SerialName("auth_time")
     override val authTime: Long,
@@ -22,17 +22,14 @@ data class CognitoAccessTokenClaims(
     @SerialName("cognito:groups")
     override val cognitoGroups: List<String>,
     @SerialName("device_key")
-    override val deviceKey: String,
-    override val email: String,
-    @SerialName("email_verified")
-    override val emailVerified: Boolean,
+    override val deviceKey: String? = null,
     @SerialName("event_id")
-    override val eventId: String,
-    override val scope: String,
+    override val eventId: String? = null,
+    override val scope: String? = null,
     @SerialName("token_use")
     override val tokenUse: String,
     override val username: String
-): AccessToken, AccessTokenExtenstion
+): AccessToken, AccessTokenExtension
 
 class CognitoAccessToken(accessTokenString: String): JWT<CognitoAccessTokenClaims>(accessTokenString) {
     override val claims: CognitoAccessTokenClaims

--- a/auth/src/commonMain/kotlin/com/liftric/auth/jwt/CognitoAccessToken.kt
+++ b/auth/src/commonMain/kotlin/com/liftric/auth/jwt/CognitoAccessToken.kt
@@ -1,0 +1,50 @@
+package com.liftric.auth.jwt
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+interface AccessTokenExtenstion {
+    val authTime: Long
+    val clientId: String
+    val cognitoGroups: List<String>
+    val deviceKey: String
+    val email: String
+    val emailVerified: Boolean
+    val eventId: String
+    val scope: String
+    val tokenUse: String
+    val username: String
+}
+
+@Serializable
+data class CognitoAccessToken(
+    override val aud: String,
+    override val exp: Long,
+    override val iat: Long,
+    override val iss: String,
+    override val jti: String,
+    override val nbf: Long,
+    override val sub: String,
+    @SerialName("auth_time")
+    override val authTime: Long,
+    @SerialName("client_id")
+    override val clientId: String,
+    @SerialName("cognito:groups")
+    override val cognitoGroups: List<String>,
+    @SerialName("device_key")
+    override val deviceKey: String,
+    override val email: String,
+    @SerialName("email_verified")
+    override val emailVerified: Boolean,
+    @SerialName("event_id")
+    override val eventId: String,
+    override val scope: String,
+    @SerialName("token_use")
+    override val tokenUse: String,
+    override val username: String
+): AccessToken, AccessTokenExtenstion {
+    fun toJsonString(): String {
+        return Json.encodeToString(serializer(), this)
+    }
+}

--- a/auth/src/commonMain/kotlin/com/liftric/auth/jwt/CognitoIdToken.kt
+++ b/auth/src/commonMain/kotlin/com/liftric/auth/jwt/CognitoIdToken.kt
@@ -1,0 +1,57 @@
+package com.liftric.auth.jwt
+
+import kotlinx.serialization.*
+import kotlinx.serialization.json.Json
+
+interface IdTokenExtenstion {
+    val aud: String
+    val authTime: Long
+    val cognitoGroups: List<String>
+    val cognitoUsername: String
+    val exp: Long
+    val eventId: String
+    val iss: String
+    val iat: Long
+    val scope: String?
+    val tokenUse: String
+    val custom: Map<String, String>?
+}
+
+@Serializable
+data class CognitoIdToken(
+    override val sub: String? = null,
+    override val name: String? = null,
+    override val givenName: String? = null,
+    override val familyName: String? = null,
+    override val middleName: String? = null,
+    override val nickname: String? = null,
+    override val preferredUsername: String? = null,
+    override val profile: String? = null,
+    override val picture: String? = null,
+    override val website: String? = null,
+    override val email: String? = null,
+    override val emailVerified: Boolean? = null,
+    override val gender: String? = null,
+    override val birthdate: String? = null,
+    override val zoneinfo: String? = null,
+    override val locale: String? = null,
+    override val phoneNumber: String? = null,
+    override val phoneNumberVerified: Boolean? = null,
+    override val address: Address? = null,
+    override val updatedAt: Long? = null,
+    override val aud: String,
+    override val authTime: Long,
+    override val cognitoGroups: List<String>,
+    override val cognitoUsername: String,
+    override val exp: Long,
+    override val eventId: String,
+    override val iss: String,
+    override val iat: Long,
+    override val scope: String? = null,
+    override val tokenUse: String,
+    override val custom: Map<String, String>? = null
+): IdToken, IdTokenExtenstion {
+    fun toJsonString(): String {
+        return Json.encodeToString(serializer(), this)
+    }
+}

--- a/auth/src/commonMain/kotlin/com/liftric/auth/jwt/CognitoIdToken.kt
+++ b/auth/src/commonMain/kotlin/com/liftric/auth/jwt/CognitoIdToken.kt
@@ -37,7 +37,7 @@ data class CognitoIdTokenClaims(
     override val iat: Long,
     override val scope: String? = null,
     override val tokenUse: String,
-    override val custom: Map<String, String>? = null
+    override val customAttributes: Map<String, String>? = null
 ): IdToken, IdTokenExtension
 
 class CognitoIdToken(idTokenString: String): JWT<CognitoIdTokenClaims>(idTokenString) {

--- a/auth/src/commonMain/kotlin/com/liftric/auth/jwt/CognitoIdToken.kt
+++ b/auth/src/commonMain/kotlin/com/liftric/auth/jwt/CognitoIdToken.kt
@@ -17,7 +17,7 @@ interface IdTokenExtenstion {
     val custom: Map<String, String>?
 }
 
-@Serializable
+@Serializable(with = CustomAttributesSerializer::class)
 data class CognitoIdToken(
     override val sub: String? = null,
     override val name: String? = null,

--- a/auth/src/commonMain/kotlin/com/liftric/auth/jwt/CognitoIdToken.kt
+++ b/auth/src/commonMain/kotlin/com/liftric/auth/jwt/CognitoIdToken.kt
@@ -44,8 +44,7 @@ class CognitoIdToken(idTokenString: String): JWT<CognitoIdTokenClaims>(idTokenSt
     override val claims: CognitoIdTokenClaims
         get() {
             try {
-                val payload = getPayload()
-                return Json.decodeFromString(CognitoIdTokenClaims.serializer(), payload)
+                return Json.decodeFromString(CognitoIdTokenClaims.serializer(), getPayload())
             } catch (e: SerializationException) {
                 throw InvalidCognitoIdTokenException("This is not a valid cognito id token")
             }

--- a/auth/src/commonMain/kotlin/com/liftric/auth/jwt/IdToken.kt
+++ b/auth/src/commonMain/kotlin/com/liftric/auth/jwt/IdToken.kt
@@ -1,0 +1,141 @@
+package com.liftric.auth.jwt
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Id Token containing OIDC standard claims
+ * @see <a href="http://openid.net/specs/openid-connect-core-1_0.html#StandardClaims">http://openid.net</a>
+ */
+interface IdToken {
+    /**
+     * Subject identifier
+     */
+    val sub: String?
+
+    /**
+     * Full name in displayable form including all name parts
+     */
+    val name: String?
+
+    /**
+     * Given name(s) or first name(s)
+     */
+    val givenName: String?
+
+    /**
+     * Surname(s) or last name(s)
+     */
+    val familyName: String?
+
+    /**
+     * Middle name(s)
+     */
+    val middleName: String?
+
+    /**
+     * Casual name that may or may not be the same as the givenName
+     */
+    val nickname: String?
+
+    /**
+     * Shorthand name
+     */
+    val preferredUsername: String?
+
+    /**
+     * URL of the profile page
+     */
+    val profile: String?
+
+    /**
+     * URL of the profile picture
+     */
+    val picture: String?
+
+    /**
+     * Web page or blog
+     */
+    val website: String?
+
+    /**
+     * Preferred email address
+     */
+    val email: String?
+
+    /**
+     * True if email has been verified
+     */
+    val emailVerified: Boolean?
+
+    /**
+     * Gender, either 'female' or 'male'
+     */
+    val gender: String?
+
+    /**
+     * Birthdate represented as an ISO 8601:2004 YYYY-MM-DD format
+     */
+    val birthdate: String?
+
+    /**
+     * String from zoneinfo time zone database representing the time zone
+     */
+    val zoneinfo: String?
+
+    /**
+     * Locale, represented as a BCP47 language tag
+     */
+    val locale: String?
+
+    /**
+     * Preferred telephone number
+     */
+    val phoneNumber: String?
+
+    /**
+     * True if phone number has been verified
+     */
+    val phoneNumberVerified: Boolean?
+
+    /**
+     * Preferred postal address
+     */
+    val address: Address?
+
+    /**
+     * Time the information was last updated
+     */
+    val updatedAt: Long?
+}
+
+/**
+ * Address claim as specified by OIDC
+ * @see <a href="https://openid.net/specs/openid-connect-core-1_0.html#AddressClaim">http://openid.net</a>
+ */
+@Serializable
+data class Address (
+    /**
+     * Full mailing address, formatted for display or use on a mailing label
+     */
+    val formatted: String? = null,
+    /**
+     * Full street address
+     */
+    val streetAddress: String? = null,
+    /**
+     * City or locality
+     */
+    val locality: String? = null,
+    /**
+     * State, province, prefecture, or region
+     */
+    val region: String? = null,
+    /**
+     * Zip code or postal code
+     */
+    val postalCode: String? = null,
+    /**
+     * Country name
+     */
+    val country: String? = null
+)

--- a/auth/src/commonMain/kotlin/com/liftric/auth/jwt/IdToken.kt
+++ b/auth/src/commonMain/kotlin/com/liftric/auth/jwt/IdToken.kt
@@ -139,3 +139,17 @@ data class Address (
      */
     val country: String? = null
 )
+
+interface IdTokenExtension {
+    val aud: String
+    val authTime: Long
+    val cognitoGroups: List<String>
+    val cognitoUsername: String
+    val exp: Long
+    val eventId: String
+    val iss: String
+    val iat: Long
+    val scope: String?
+    val tokenUse: String
+    val custom: Map<String, String>?
+}

--- a/auth/src/commonMain/kotlin/com/liftric/auth/jwt/IdToken.kt
+++ b/auth/src/commonMain/kotlin/com/liftric/auth/jwt/IdToken.kt
@@ -141,15 +141,58 @@ data class Address (
 )
 
 interface IdTokenExtension {
+    /**
+     * Audience
+     */
     val aud: String
+
+    /**
+     * Time when the authentication occurred. JSON number that represents the number of seconds from 1970-01-01T0:0:0Z as measured in UTC format
+     */
     val authTime: Long
+
+    /**
+     * List of groups the user belongs to
+     */
     val cognitoGroups: List<String>
+
+    /**
+     * Username
+     */
     val cognitoUsername: String
+
+    /**
+     * Expiration time
+     */
     val exp: Long
+
+    /**
+     * Event id
+     */
     val eventId: String
+
+    /**
+     * Issuer
+     */
     val iss: String
+
+    /**
+     * Issued at
+     */
     val iat: Long
+
+    /**
+     * List of Oauth 2.0 scopes that define what access the token provides
+     */
     val scope: String?
+
+    /**
+     * Intended purpose of this token. Its value is always id
+     */
     val tokenUse: String
-    val custom: Map<String, String>?
+
+    /**
+     * Custom cognito attributes
+     */
+    val customAttributes: Map<String, String>?
 }

--- a/auth/src/commonMain/kotlin/com/liftric/auth/jwt/IdTokenSerializer.kt
+++ b/auth/src/commonMain/kotlin/com/liftric/auth/jwt/IdTokenSerializer.kt
@@ -1,0 +1,196 @@
+package com.liftric.auth.jwt
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializer
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.*
+
+@Serializer(forClass = CognitoIdToken::class)
+internal object CustomAttributesSerializer : KSerializer<CognitoIdToken> {
+    private val stringToJsonElementSerializer = MapSerializer(String.serializer(), JsonElement.serializer())
+
+    override val descriptor: SerialDescriptor = stringToJsonElementSerializer.descriptor
+
+    override fun deserialize(decoder: Decoder): CognitoIdToken {
+        require(decoder is JsonDecoder)
+        val json = decoder.json
+        val filtersMap = decoder.decodeSerializableValue(stringToJsonElementSerializer)
+
+        val address = filtersMap["address"]?.let {
+            json.decodeFromJsonElement(Address.serializer(), it)
+        }
+        val birthdate = filtersMap["birthdate"]?.let {
+            json.decodeFromJsonElement(String.serializer(), it)
+        }
+        val email = filtersMap["email"]?.let {
+            json.decodeFromJsonElement(String.serializer(), it)
+        }
+        val emailVerified = filtersMap["email_verified"]?.let {
+            json.decodeFromJsonElement(Boolean.serializer(), it)
+        }
+        val familyName = filtersMap["family_name"]?.let {
+            json.decodeFromJsonElement(String.serializer(), it)
+        }
+        val middleName = filtersMap["middle_name"]?.let {
+            json.decodeFromJsonElement(String.serializer(), it)
+        }
+        val gender = filtersMap["gender"]?.let {
+            json.decodeFromJsonElement(String.serializer(), it)
+        }
+        val givenName = filtersMap["given_name"]?.let {
+            json.decodeFromJsonElement(String.serializer(), it)
+        }
+        val locale = filtersMap["locale"]?.let {
+            json.decodeFromJsonElement(String.serializer(), it)
+        }
+        val name = filtersMap["name"]?.let {
+            json.decodeFromJsonElement(String.serializer(), it)
+        }
+        val nickname = filtersMap["nickname"]?.let {
+            json.decodeFromJsonElement(String.serializer(), it)
+        }
+        val phoneNumber = filtersMap["phone_number"]?.let {
+            json.decodeFromJsonElement(String.serializer(), it)
+        }
+        val phoneNumberVerified = filtersMap["phone_number_verified"]?.let {
+            json.decodeFromJsonElement(Boolean.serializer(), it)
+        }
+        val picture = filtersMap["picture"]?.let {
+            json.decodeFromJsonElement(String.serializer(), it)
+        }
+        val profile = filtersMap["profile"]?.let {
+            json.decodeFromJsonElement(String.serializer(), it)
+        }
+        val preferredUsername = filtersMap["preferred_username"]?.let {
+            json.decodeFromJsonElement(String.serializer(), it)
+        }
+        val sub = filtersMap["sub"]?.let {
+            json.decodeFromJsonElement(String.serializer(), it)
+        }
+        val aud = filtersMap["aud"]?.let {
+            json.decodeFromJsonElement(String.serializer(), it)
+        }!!
+        val authTime = filtersMap["auth_time"]?.let {
+            json.decodeFromJsonElement(Long.serializer(), it)
+        }!!
+        val cognitoGroups = filtersMap["cognito:groups"]?.let {
+            json.decodeFromJsonElement(ListSerializer(String.serializer()), it)
+        }!!
+        val cognitoUsername = filtersMap["cognito:username"]?.let {
+            json.decodeFromJsonElement(String.serializer(), it)
+        }!!
+        val exp = filtersMap["exp"]?.let {
+            json.decodeFromJsonElement(Long.serializer(), it)
+        }!!
+        val eventId = filtersMap["event_id"]?.let {
+            json.decodeFromJsonElement(String.serializer(), it)
+        }!!
+        val iss = filtersMap["iss"]?.let {
+            json.decodeFromJsonElement(String.serializer(), it)
+        }!!
+        val zoneinfo = filtersMap["zoneinfo"]?.let {
+            json.decodeFromJsonElement(String.serializer(), it)
+        }
+        val iat = filtersMap["iat"]?.let {
+            json.decodeFromJsonElement(Long.serializer(), it)
+        }!!
+        val scope = filtersMap["scope"]?.let {
+            json.decodeFromJsonElement(String.serializer(), it)
+        }
+        val tokenUse = filtersMap["token_use"]?.let {
+            json.decodeFromJsonElement(String.serializer(), it)
+        }!!
+        val website = filtersMap["website"]?.let {
+            json.decodeFromJsonElement(String.serializer(), it)
+        }
+        val updatedAt = filtersMap["updated_at"]?.let {
+            json.decodeFromJsonElement(Long.serializer(), it)
+        }
+        val unknownFilters = filtersMap.filter { (key, _) -> key.contains("custom") }
+        val customAttributes = mutableMapOf<String, String>()
+        unknownFilters.forEach {
+            val value = json.decodeFromJsonElement(String.serializer(), it.value)
+            customAttributes[it.key] = value
+        }
+
+        return CognitoIdToken(
+            sub,
+            name,
+            givenName,
+            familyName,
+            middleName,
+            nickname,
+            preferredUsername,
+            profile,
+            picture,
+            website,
+            email,
+            emailVerified,
+            gender,
+            birthdate,
+            zoneinfo,
+            locale,
+            phoneNumber,
+            phoneNumberVerified,
+            address,
+            updatedAt,
+            aud,
+            authTime,
+            cognitoGroups,
+            cognitoUsername,
+            exp,
+            eventId,
+            iss,
+            iat,
+            scope,
+            tokenUse,
+            customAttributes
+        )
+    }
+    override fun serialize(encoder: Encoder, value: CognitoIdToken) {
+        require(encoder is JsonEncoder)
+        val json = encoder.json
+        val map: MutableMap<String, JsonElement> = mutableMapOf()
+
+        value.sub?.let { map["name"] = json.encodeToJsonElement(String.serializer(), it) }
+        value.name?.let { map["name"] = json.encodeToJsonElement(String.serializer(), it) }
+        value.givenName?.let { map["given_name"] = json.encodeToJsonElement(String.serializer(), it) }
+        value.familyName?.let { map["family_name"] = json.encodeToJsonElement(String.serializer(), it) }
+        value.middleName?.let { map["middle_name"] = json.encodeToJsonElement(String.serializer(), it) }
+        value.nickname?.let { map["nickname"] = json.encodeToJsonElement(String.serializer(), it) }
+        value.preferredUsername?.let { map["preferred_username"] = json.encodeToJsonElement(String.serializer(), it) }
+        value.profile?.let { map["profile"] = json.encodeToJsonElement(String.serializer(), it) }
+        value.picture?.let { map["picture"] = json.encodeToJsonElement(String.serializer(), it) }
+        value.website?.let { map["website"] = json.encodeToJsonElement(String.serializer(), it) }
+        value.email?.let { map["email"] = json.encodeToJsonElement(String.serializer(), it) }
+        value.emailVerified?.let { map["email_verified"] = json.encodeToJsonElement(Boolean.serializer(), it) }
+        value.gender?.let { map["gender"] = json.encodeToJsonElement(String.serializer(), it) }
+        value.birthdate?.let { map["birthdate"] = json.encodeToJsonElement(String.serializer(), it) }
+        value.zoneinfo?.let { map["zoneinfo"] = json.encodeToJsonElement(String.serializer(), it) }
+        value.locale?.let { map["locale"] = json.encodeToJsonElement(String.serializer(), it) }
+        value.phoneNumber?.let { map["phone_number"] = json.encodeToJsonElement(String.serializer(), it) }
+        value.phoneNumberVerified?.let { map["phone_number_verified"] = json.encodeToJsonElement(Boolean.serializer(), it) }
+        value.address?.let { map["address"] = json.encodeToJsonElement(Address.serializer(), it) }
+        value.updatedAt?.let { map["updated_at"] = json.encodeToJsonElement(Long.serializer(), it) }
+        value.aud.let { map["aud"] = json.encodeToJsonElement(String.serializer(), it) }
+        value.authTime.let { map["auth_time"] = json.encodeToJsonElement(Long.serializer(), it) }
+        value.cognitoGroups.let { map["cognito:groups"] = json.encodeToJsonElement(ListSerializer(String.serializer()), it) }
+        value.cognitoUsername.let { map["cognito:username"] = json.encodeToJsonElement(String.serializer(), it) }
+        value.exp.let { map["exp"] = json.encodeToJsonElement(Long.serializer(), it) }
+        value.eventId.let { map["event_id"] = json.encodeToJsonElement(String.serializer(), it) }
+        value.iss.let { map["iss"] = json.encodeToJsonElement(String.serializer(), it) }
+        value.iat.let { map["iat"] = json.encodeToJsonElement(Long.serializer(), it) }
+        value.scope?.let { map["scope"] = json.encodeToJsonElement(String.serializer(), it) }
+        value.tokenUse.let { map["token_user"] = json.encodeToJsonElement(String.serializer(), it) }
+        value.custom?.forEach {
+            map[it.key] = json.encodeToJsonElement(String.serializer(), it.value)
+        }
+
+        encoder.encodeSerializableValue(stringToJsonElementSerializer, map)
+    }
+}

--- a/auth/src/commonMain/kotlin/com/liftric/auth/jwt/IdTokenSerializer.kt
+++ b/auth/src/commonMain/kotlin/com/liftric/auth/jwt/IdTokenSerializer.kt
@@ -133,7 +133,11 @@ internal object CustomAttributesSerializer : KSerializer<CognitoIdTokenClaims> {
         val unknownFilters = filtersMap.filter { (key, _) -> key.contains("custom") }
         val customAttributes = mutableMapOf<String, String>()
         unknownFilters.forEach {
-            val value = json.decodeFromJsonElement(String.serializer(), it.value)
+            val value = if (it.value.jsonPrimitive.isString) {
+                json.decodeFromJsonElement(String.serializer(), it.value)
+            } else {
+                json.decodeFromJsonElement(Long.serializer(), it.value).toString()
+            }
             customAttributes[it.key] = value
         }
 
@@ -206,7 +210,7 @@ internal object CustomAttributesSerializer : KSerializer<CognitoIdTokenClaims> {
         value.iat.let { map["iat"] = json.encodeToJsonElement(Long.serializer(), it) }
         value.scope?.let { map["scope"] = json.encodeToJsonElement(String.serializer(), it) }
         value.tokenUse.let { map["token_user"] = json.encodeToJsonElement(String.serializer(), it) }
-        value.custom?.forEach {
+        value.customAttributes?.forEach {
             map[it.key] = json.encodeToJsonElement(String.serializer(), it.value)
         }
 

--- a/auth/src/commonMain/kotlin/com/liftric/auth/jwt/IdTokenSerializer.kt
+++ b/auth/src/commonMain/kotlin/com/liftric/auth/jwt/IdTokenSerializer.kt
@@ -1,6 +1,7 @@
 package com.liftric.auth.jwt
 
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.Serializer
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.MapSerializer
@@ -11,12 +12,12 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.*
 
 @Serializer(forClass = CognitoIdToken::class)
-internal object CustomAttributesSerializer : KSerializer<CognitoIdToken> {
+internal object CustomAttributesSerializer : KSerializer<CognitoIdTokenClaims> {
     private val stringToJsonElementSerializer = MapSerializer(String.serializer(), JsonElement.serializer())
 
     override val descriptor: SerialDescriptor = stringToJsonElementSerializer.descriptor
 
-    override fun deserialize(decoder: Decoder): CognitoIdToken {
+    override fun deserialize(decoder: Decoder): CognitoIdTokenClaims {
         require(decoder is JsonDecoder)
         val json = decoder.json
         val filtersMap = decoder.decodeSerializableValue(stringToJsonElementSerializer)
@@ -74,37 +75,55 @@ internal object CustomAttributesSerializer : KSerializer<CognitoIdToken> {
         }
         val aud = filtersMap["aud"]?.let {
             json.decodeFromJsonElement(String.serializer(), it)
-        }!!
+        }?: run {
+            throw SerializationException("Missing field aud")
+        }
         val authTime = filtersMap["auth_time"]?.let {
             json.decodeFromJsonElement(Long.serializer(), it)
-        }!!
+        }?: run {
+            throw SerializationException("Missing field auth_time")
+        }
         val cognitoGroups = filtersMap["cognito:groups"]?.let {
             json.decodeFromJsonElement(ListSerializer(String.serializer()), it)
-        }!!
+        }?: run {
+            throw SerializationException("Missing field cognito:groups")
+        }
         val cognitoUsername = filtersMap["cognito:username"]?.let {
             json.decodeFromJsonElement(String.serializer(), it)
-        }!!
+        }?: run {
+            throw SerializationException("Missing field cognito:username")
+        }
         val exp = filtersMap["exp"]?.let {
             json.decodeFromJsonElement(Long.serializer(), it)
-        }!!
+        }?: run {
+            throw SerializationException("Missing field exp")
+        }
         val eventId = filtersMap["event_id"]?.let {
             json.decodeFromJsonElement(String.serializer(), it)
-        }!!
+        }?: run {
+            throw SerializationException("Missing field event_id")
+        }
         val iss = filtersMap["iss"]?.let {
             json.decodeFromJsonElement(String.serializer(), it)
-        }!!
+        }?: run {
+            throw SerializationException("Missing field iss")
+        }
         val zoneinfo = filtersMap["zoneinfo"]?.let {
             json.decodeFromJsonElement(String.serializer(), it)
         }
         val iat = filtersMap["iat"]?.let {
             json.decodeFromJsonElement(Long.serializer(), it)
-        }!!
+        }?: run {
+            throw SerializationException("Missing field iat")
+        }
         val scope = filtersMap["scope"]?.let {
             json.decodeFromJsonElement(String.serializer(), it)
         }
         val tokenUse = filtersMap["token_use"]?.let {
             json.decodeFromJsonElement(String.serializer(), it)
-        }!!
+        }?: run {
+            throw SerializationException("Missing field token_use")
+        }
         val website = filtersMap["website"]?.let {
             json.decodeFromJsonElement(String.serializer(), it)
         }
@@ -118,7 +137,7 @@ internal object CustomAttributesSerializer : KSerializer<CognitoIdToken> {
             customAttributes[it.key] = value
         }
 
-        return CognitoIdToken(
+        return CognitoIdTokenClaims(
             sub,
             name,
             givenName,
@@ -152,7 +171,7 @@ internal object CustomAttributesSerializer : KSerializer<CognitoIdToken> {
             customAttributes
         )
     }
-    override fun serialize(encoder: Encoder, value: CognitoIdToken) {
+    override fun serialize(encoder: Encoder, value: CognitoIdTokenClaims) {
         require(encoder is JsonEncoder)
         val json = encoder.json
         val map: MutableMap<String, JsonElement> = mutableMapOf()

--- a/auth/src/commonMain/kotlin/com/liftric/auth/jwt/JWT.kt
+++ b/auth/src/commonMain/kotlin/com/liftric/auth/jwt/JWT.kt
@@ -1,0 +1,2 @@
+package com.liftric.auth.jwt
+

--- a/auth/src/commonMain/kotlin/com/liftric/auth/jwt/JWT.kt
+++ b/auth/src/commonMain/kotlin/com/liftric/auth/jwt/JWT.kt
@@ -31,7 +31,7 @@ abstract class JWT<T>(private val tokenString: String) {
     private fun validateComponents(): List<String> {
         val components = tokenString.split(".")
         if (components.size != 3) {
-            throw MissingComponentsException("${components.size} out of 3 components of a valid JWT missing")
+            throw MissingComponentsException("Has ${components.size} components, should be 3 components")
         }
         return components
     }

--- a/auth/src/commonMain/kotlin/com/liftric/auth/jwt/JWT.kt
+++ b/auth/src/commonMain/kotlin/com/liftric/auth/jwt/JWT.kt
@@ -1,2 +1,46 @@
 package com.liftric.auth.jwt
 
+class MissingComponentsException(message:String): Exception(message)
+class InvalidBase64Exception(message:String): Exception(message)
+
+/**
+ * Abstract base class that represents a JWT
+ * Consists of convenience methods and an
+ * abstract claims variable that has to be implemented
+ * by the class that conforms to the object
+ */
+abstract class JWT<T>(private val tokenString: String) {
+    /**
+     * Access to the claims of the payload
+     */
+    abstract val claims: T
+
+    /**
+     * Provides access to the payload of the token
+     * @return decoded Json String
+     */
+    fun getPayload(): String {
+        val component = validateComponents()[1]
+        return decodeBase64String(component)
+    }
+
+    /**
+     * Validates if all three components a present
+     * @throws MissingComponentsException when components count is not equal 3
+     */
+    private fun validateComponents(): List<String> {
+        val components = tokenString.split(".")
+        if (components.size != 3) {
+            throw MissingComponentsException("${components.size} out of 3 components of a valid JWT missing")
+        }
+        return components
+    }
+
+    /**
+     * Decodes Base64 encoded component
+     * @throws InvalidBase64Exception when not valid Base64 encoded string
+     */
+    private fun decodeBase64String(component: String): String {
+        return Base64.decode(component)?: throw InvalidBase64Exception("Not a valid Base64 encoded string")
+    }
+}

--- a/auth/src/commonTest/kotlin/com/liftric/auth/AuthHandlerIntegrationTests.kt
+++ b/auth/src/commonTest/kotlin/com/liftric/auth/AuthHandlerIntegrationTests.kt
@@ -280,7 +280,7 @@ abstract class AbstractAuthHandlerIntegrationTests() {
 
     @JsName("GetCustomAttributes")
     @Test
-    fun `Test if gets custom attributes`() {
+    fun `Test if custom attributes get mapped correctly`() {
         val token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI3NTUzZGRmOC1hMTAzLTRjYjItOWVkZi0yNDcwMTBmNGNjNGQiLCJhdWQiOiIzdjRzNm9lMmRobjZua2hydTU3OWc2bTZnMSIsImNvZ25pdG86Z3JvdXBzIjpbIlJPTEVfUEFUSUVOVCJdLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImV2ZW50X2lkIjoiZmMxNTM3NTQtNDY5ZS00YzZiLTlhMzktODVhM2M3MDAxZTMwIiwidG9rZW5fdXNlIjoiaWQiLCJhdXRoX3RpbWUiOjE1OTk1NjY5MjMsImlzcyI6Imh0dHBzOi8vY29nbml0by1pZHAuZXUtY2VudHJhbC0xLmFtYXpvbmF3cy5jb20vZXUtY2VudHJhbC0xX0MxR243SGJZTiIsImNvZ25pdG86dXNlcm5hbWUiOiI2YTg0MzYzNS1kZWM2LTQxMmYtYjI0MS1iNGRmYmI2NTVkM2YiLCJleHAiOjE2MDEzMDE1ODYsImlhdCI6MTU5OTU2NjkyMywiZW1haWwiOiJ0ZXN0QHRlc3QuY29tIiwiY3VzdG9tOnR3aXR0ZXIiOiJ0ZXN0IiwiY3VzdG9tOmFnZSI6MTgsImp0aSI6ImI0NjE2MzZmLWUxOGMtNDhjZi04Mjk5LTUzYjZmMWIxNWZmMyJ9.Mzh2RGW1VWd1oxE89xW05Ce_JRs1Y2HifL3brBkf7NE"
         val idToken = CognitoIdToken(token)
         assertNotNull(idToken.claims.customAttributes?.get("custom:age"))
@@ -322,7 +322,7 @@ abstract class AbstractAuthHandlerIntegrationTests() {
     @Test
     fun `Test should throw InvalidBase64Exception since it is not a base 64 encoded string`() {
         assertFailsWith(InvalidBase64Exception::class) {
-            val token = "This is a string.EOKF36syRBtB11VgyChkNjc1HxRrajT7XXaxZfnVzPkV57K3b9yqkS284Ovb9uWzXgGeY2bxA3IySGfdOHiPAQ==F/v6hcTiU1sd975XHfDsz8o0rboujM77n7KwRMidobOLbo5ghUT/IFcxElUc8CirdZxaCaS3zs/CfRKRsXwbFNYd.the amount that is needed for a JWT"
+            val token = "component.EOKF36syRBtB11VgyChkNjc1HxRrajT7XXaxZfnVzPkV57K3b9yqkS284Ovb9uWzXgGeY2bxA3IySGfdOHiPAQ==F/v6hcTiU1sd975XHfDsz8o0rboujM77n7KwRMidobOLbo5ghUT/IFcxElUc8CirdZxaCaS3zs/CfRKRsXwbFNYd.component"
             val idToken = CognitoIdToken(token)
             idToken.getPayload()
         }
@@ -335,6 +335,16 @@ abstract class AbstractAuthHandlerIntegrationTests() {
             val token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiIzdjRzNm9lMmRobjZua2hydTU3OWc2bTZnMSIsImNvZ25pdG86Z3JvdXBzIjpbIlJPTEVfUEFUSUVOVCJdLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImV2ZW50X2lkIjoiZmMxNTM3NTQtNDY5ZS00YzZiLTlhMzktODVhM2M3MDAxZTMwIiwidG9rZW5fdXNlIjoiaWQiLCJhdXRoX3RpbWUiOjE1OTk1NjY5MjMsImNvZ25pdG86dXNlcm5hbWUiOiI2YTg0MzYzNS1kZWM2LTQxMmYtYjI0MS1iNGRmYmI2NTVkM2YiLCJleHAiOjE2MDEyOTQ1NDQsImlhdCI6MTU5OTU2NjkyMywiZW1haWxfd2l0aF90eXBvIjoiZ2FlYmVsQGxpZnRyaWMuY29tIiwianRpIjoiYWNkNjg1MTUtZmExZi00ZTNmLWI3ZmUtODEwYzY2NmRhODYwIn0.zuqwEPXiLzbmxSdNQGjr3m4X5cXqdQf4aw_-7BUbvZk"
             val idToken = CognitoIdToken(token)
             idToken.claims
+        }
+    }
+
+    @JsName("ShouldThrowInvalidCognitoAccessTokenException")
+    @Test
+    fun `Test should throw InvalidCognitoAccessTokenException since this is not a valid Cognito Access token`() {
+        assertFailsWith(InvalidCognitoAccessTokenException::class) {
+            val token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiIzdjRzNm9lMmRobjZua2hydTU3OWc2bTZnMSIsImNvZ25pdG86Z3JvdXBzIjpbIlJPTEVfUEFUSUVOVCJdLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImV2ZW50X2lkIjoiZmMxNTM3NTQtNDY5ZS00YzZiLTlhMzktODVhM2M3MDAxZTMwIiwidG9rZW5fdXNlIjoiaWQiLCJhdXRoX3RpbWUiOjE1OTk1NjY5MjMsImNvZ25pdG86dXNlcm5hbWUiOiI2YTg0MzYzNS1kZWM2LTQxMmYtYjI0MS1iNGRmYmI2NTVkM2YiLCJleHAiOjE2MDEyOTQ1NDQsImlhdCI6MTU5OTU2NjkyMywiZW1haWxfd2l0aF90eXBvIjoiZ2FlYmVsQGxpZnRyaWMuY29tIiwianRpIjoiYWNkNjg1MTUtZmExZi00ZTNmLWI3ZmUtODEwYzY2NmRhODYwIn0.zuqwEPXiLzbmxSdNQGjr3m4X5cXqdQf4aw_-7BUbvZk"
+            val accessToken = CognitoAccessToken(token)
+            accessToken.claims
         }
     }
 }

--- a/auth/src/commonTest/kotlin/com/liftric/auth/AuthHandlerIntegrationTests.kt
+++ b/auth/src/commonTest/kotlin/com/liftric/auth/AuthHandlerIntegrationTests.kt
@@ -258,14 +258,24 @@ abstract class AbstractAuthHandlerIntegrationTests() {
         assertEquals("Invalid Access Token", updateUserAttributesResponse.exceptionOrNull()!!.message)
     }
 
-    @JsName("GetClaimsWithoutEmailTest")
+    @JsName("TestGetIdTokenClaimsWithEmailNullValue")
     @Test
-    fun `Test if get claims works without email address`() {
+    fun `Test if get id token  claims works without email address`() {
         val token = "eyJraWQiOiJwREgwTUpqeWdoRk4wT2J1cFpUNzl1QytLZkpZQ3BtNnZTamVXb3NpZUlFPSIsImFsZyI6IlJTMjU2In0.eyJzdWIiOiIxZWEyMTg1Yi1iYTk5LTRlYjUtYmZkMS0yMDY0MjQ2Yzc0NWQiLCJhdWQiOiIzdjRzNm9lMmRobjZua2hydTU3OWc2bTZnMSIsImNvZ25pdG86Z3JvdXBzIjpbIlJPTEVfUEFUSUVOVCJdLCJldmVudF9pZCI6IjA3ODE5NGUzLTM5YzQtNDBhYS04MzkwLTkzMmI2MjY2MjE3YSIsInRva2VuX3VzZSI6ImlkIiwiYXV0aF90aW1lIjoxNTk5NTY1OTU4LCJpc3MiOiJodHRwczpcL1wvY29nbml0by1pZHAuZXUtY2VudHJhbC0xLmFtYXpvbmF3cy5jb21cL2V1LWNlbnRyYWwtMV9DMUduN0hiWU4iLCJjb2duaXRvOnVzZXJuYW1lIjoiNDMzMGI4ZjctYmRjMy00MTI2LTllYWUtZWVkZTc0ZTI0MTEyIiwiZXhwIjoxNTk5NTY5NTU4LCJpYXQiOjE1OTk1NjU5NTh9.hLzDOItbHkUWYyI9hTFIKkoC50_UrRnPFoIcyrsiCzP5zQFlhTboe9TZ6BE0o21IEk8tcdBkFRHbuM8zPru-qopB9tC7pkhvY1FoPMlNlRSmqj8YZjJ8InnHForkdJ4n9keM8PcdwW6KWlAjLViwSmOl3k-ptQq1DnmnmGmcmfzssDzON0R__jsyEQs_EZWQ3c86qodbIU4peN9Dm26TMSQCzJhZwvCuGRmRgplsqOD4UfDVh5ya-bXUogJuirlE8KFUH1my13AJOxAJLBgyOjBZceFMnC4ZqZBbSND-iiMvQcpn4O6gd5p5Je367LO56w_ypo6eMffEs39fikIP4g"
         val idToken = CognitoIdToken(token)
         assertEquals(idToken.claims.sub, "1ea2185b-ba99-4eb5-bfd1-2064246c745d")
         assertEquals(idToken.claims.email, null)
         assertEquals(idToken.claims.emailVerified, null)
+    }
+
+    @JsName("TestGetIdTokenClaimsWithEmail")
+    @Test
+    fun `Test if get id token claims works with email address`() {
+        val token = "eyJraWQiOiJwREgwTUpqeWdoRk4wT2J1cFpUNzl1QytLZkpZQ3BtNnZTamVXb3NpZUlFPSIsImFsZyI6IlJTMjU2In0.eyJzdWIiOiI3NTUzZGRmOC1hMTAzLTRjYjItOWVkZi0yNDcwMTBmNGNjNGQiLCJhdWQiOiIzdjRzNm9lMmRobjZua2hydTU3OWc2bTZnMSIsImNvZ25pdG86Z3JvdXBzIjpbIlJPTEVfUEFUSUVOVCJdLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImV2ZW50X2lkIjoiZmMxNTM3NTQtNDY5ZS00YzZiLTlhMzktODVhM2M3MDAxZTMwIiwidG9rZW5fdXNlIjoiaWQiLCJhdXRoX3RpbWUiOjE1OTk1NjY5MjMsImlzcyI6Imh0dHBzOlwvXC9jb2duaXRvLWlkcC5ldS1jZW50cmFsLTEuYW1hem9uYXdzLmNvbVwvZXUtY2VudHJhbC0xX0MxR243SGJZTiIsImNvZ25pdG86dXNlcm5hbWUiOiI2YTg0MzYzNS1kZWM2LTQxMmYtYjI0MS1iNGRmYmI2NTVkM2YiLCJleHAiOjE1OTk1NzA1MjMsImlhdCI6MTU5OTU2NjkyMywiZW1haWwiOiJnYWViZWxAbGlmdHJpYy5jb20ifQ.ka1nCmT-ACwbvQ3uy3qsuZII6PQzdfJHA7UY3Wkt_7GU2fxBxcDdRjzdDdCmh4IE0e0uwfoddMXTXWaijo6yKvrv0VHtfsIkfFJb09TNtCNrxTy1PX-bJNeVT752N85pdNpkms6GefylP2iAZec520ISI1ZrHz0jlKfUq6iGpq3GKxIXJZ_dQGVPa2oTQDqG_CmOsr9sTRl8EoMoEIjxJdOAFeYltlPDcuhWZVUWsfwUq290UdOTBJhGruIre-cdfe03FEo9NG67mewldRYdsjNBgGQU_Jyp68hg1UQHrhKC-eUDmrWiyYGzKwbkUCCm1puwcy_wpu5HRQfjAjVW4A"
+        val idToken = CognitoIdToken(token)
+        assertEquals(idToken.claims.sub, "7553ddf8-a103-4cb2-9edf-247010f4cc4d")
+        assertNotEquals(idToken.claims.email, null)
+        assertEquals(idToken.claims.emailVerified, false)
     }
 
     @JsName("GetClaimsWithEmailTest")
@@ -276,7 +286,36 @@ abstract class AbstractAuthHandlerIntegrationTests() {
         assertEquals(idToken.claims.sub, "7553ddf8-a103-4cb2-9edf-247010f4cc4d")
         assertNotEquals(idToken.claims.email, null)
         assertEquals(idToken.claims.emailVerified, false)
+    }
 
+    @JsName("GetCustomAttributes")
+    @Test
+    fun `Test if gets custom attributes`() {
+        val token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI3NTUzZGRmOC1hMTAzLTRjYjItOWVkZi0yNDcwMTBmNGNjNGQiLCJhdWQiOiIzdjRzNm9lMmRobjZua2hydTU3OWc2bTZnMSIsImNvZ25pdG86Z3JvdXBzIjpbIlJPTEVfUEFUSUVOVCJdLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImV2ZW50X2lkIjoiZmMxNTM3NTQtNDY5ZS00YzZiLTlhMzktODVhM2M3MDAxZTMwIiwidG9rZW5fdXNlIjoiaWQiLCJhdXRoX3RpbWUiOjE1OTk1NjY5MjMsImlzcyI6Imh0dHBzOi8vY29nbml0by1pZHAuZXUtY2VudHJhbC0xLmFtYXpvbmF3cy5jb20vZXUtY2VudHJhbC0xX0MxR243SGJZTiIsImNvZ25pdG86dXNlcm5hbWUiOiI2YTg0MzYzNS1kZWM2LTQxMmYtYjI0MS1iNGRmYmI2NTVkM2YiLCJleHAiOjE2MDEzMDE1ODYsImlhdCI6MTU5OTU2NjkyMywiZW1haWwiOiJ0ZXN0QHRlc3QuY29tIiwiY3VzdG9tOnR3aXR0ZXIiOiJ0ZXN0IiwiY3VzdG9tOmFnZSI6MTgsImp0aSI6ImI0NjE2MzZmLWUxOGMtNDhjZi04Mjk5LTUzYjZmMWIxNWZmMyJ9.Mzh2RGW1VWd1oxE89xW05Ce_JRs1Y2HifL3brBkf7NE"
+        val idToken = CognitoIdToken(token)
+        assertNotNull(idToken.claims.customAttributes?.get("custom:age"))
+        assertNotNull(idToken.claims.customAttributes?.get("custom:twitter"))
+        assertEquals(idToken.claims.customAttributes?.get("custom:age")?.toLong(), 18)
+        assertEquals(idToken.claims.customAttributes?.get("custom:twitter"), "test")
+    }
+
+    @JsName("TestGetAccessTokenClaims")
+    @Test
+    fun `Test if get access token claims`() {
+        val token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhYWFhYWFhYS1iYmJiLWNjY2MtZGRkZC1lZWVlZWVlZWVlZWUiLCJkZXZpY2Vfa2V5IjoiYWFhYWFhYWEtYmJiYi1jY2NjLWRkZGQtZWVlZWVlZWVlZWVlIiwiY29nbml0bzpncm91cHMiOlsiYWRtaW4iXSwidG9rZW5fdXNlIjoiYWNjZXNzIiwic2NvcGUiOiJhd3MuY29nbml0by5zaWduaW4udXNlci5hZG1pbiIsImF1dGhfdGltZSI6MTU2MjE5MDUyNCwiaXNzIjoiaHR0cHM6Ly9jb2duaXRvLWlkcC51cy13ZXN0LTIuYW1hem9uYXdzLmNvbS91cy13ZXN0LTJfZXhhbXBsZSIsImV4cCI6MTYwMTI5ODY0MiwiaWF0IjoxNTYyMTkwNTI0LCJqdGkiOiJhYWFhYWFhYS1iYmJiLWNjY2MtZGRkZC1lZWVlZWVlZWVlZWUiLCJjbGllbnRfaWQiOiI1N2NiaXNoazRqMjRwYWJjMTIzNDU2Nzg5MCIsInVzZXJuYW1lIjoiamFuZWRvZUBleGFtcGxlLmNvbSJ9.AYrQOiqkjy6XyF33jAYje-hVfX5OnuiYUhh8pS1wxBk"
+        val accessToken = CognitoAccessToken(token)
+        assertEquals(accessToken.claims.sub, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+        assertEquals(accessToken.claims.deviceKey, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+        assertEquals(accessToken.claims.cognitoGroups[0], "admin")
+        assertEquals(accessToken.claims.tokenUse, "access")
+        assertEquals(accessToken.claims.scope, "aws.cognito.signin.user.admin")
+        assertEquals(accessToken.claims.authTime, 1562190524)
+        assertEquals(accessToken.claims.iss, "https://cognito-idp.us-west-2.amazonaws.com/us-west-2_example")
+        assertEquals(accessToken.claims.exp, 1601298642)
+        assertEquals(accessToken.claims.iat, 1562190524)
+        assertEquals(accessToken.claims.jti, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+        assertEquals(accessToken.claims.clientId, "57cbishk4j24pabc1234567890")
+        assertEquals(accessToken.claims.username, "janedoe@example.com")
     }
 
     @JsName("ShouldThrowMissingComponentsException")

--- a/auth/src/commonTest/kotlin/com/liftric/auth/AuthHandlerIntegrationTests.kt
+++ b/auth/src/commonTest/kotlin/com/liftric/auth/AuthHandlerIntegrationTests.kt
@@ -261,7 +261,7 @@ abstract class AbstractAuthHandlerIntegrationTests() {
     @Test
     fun `Test if get claims works without email address`() {
         val token = "eyJraWQiOiJwREgwTUpqeWdoRk4wT2J1cFpUNzl1QytLZkpZQ3BtNnZTamVXb3NpZUlFPSIsImFsZyI6IlJTMjU2In0.eyJzdWIiOiIxZWEyMTg1Yi1iYTk5LTRlYjUtYmZkMS0yMDY0MjQ2Yzc0NWQiLCJhdWQiOiIzdjRzNm9lMmRobjZua2hydTU3OWc2bTZnMSIsImNvZ25pdG86Z3JvdXBzIjpbIlJPTEVfUEFUSUVOVCJdLCJldmVudF9pZCI6IjA3ODE5NGUzLTM5YzQtNDBhYS04MzkwLTkzMmI2MjY2MjE3YSIsInRva2VuX3VzZSI6ImlkIiwiYXV0aF90aW1lIjoxNTk5NTY1OTU4LCJpc3MiOiJodHRwczpcL1wvY29nbml0by1pZHAuZXUtY2VudHJhbC0xLmFtYXpvbmF3cy5jb21cL2V1LWNlbnRyYWwtMV9DMUduN0hiWU4iLCJjb2duaXRvOnVzZXJuYW1lIjoiNDMzMGI4ZjctYmRjMy00MTI2LTllYWUtZWVkZTc0ZTI0MTEyIiwiZXhwIjoxNTk5NTY5NTU4LCJpYXQiOjE1OTk1NjU5NTh9.hLzDOItbHkUWYyI9hTFIKkoC50_UrRnPFoIcyrsiCzP5zQFlhTboe9TZ6BE0o21IEk8tcdBkFRHbuM8zPru-qopB9tC7pkhvY1FoPMlNlRSmqj8YZjJ8InnHForkdJ4n9keM8PcdwW6KWlAjLViwSmOl3k-ptQq1DnmnmGmcmfzssDzON0R__jsyEQs_EZWQ3c86qodbIU4peN9Dm26TMSQCzJhZwvCuGRmRgplsqOD4UfDVh5ya-bXUogJuirlE8KFUH1my13AJOxAJLBgyOjBZceFMnC4ZqZBbSND-iiMvQcpn4O6gd5p5Je367LO56w_ypo6eMffEs39fikIP4g"
-        authHandler.getClaims(token)
+        authHandler.idTokenPayload(token)
             .onSuccess { claims ->
                 assertNotNull(claims)
                 assertEquals(claims.sub, "1ea2185b-ba99-4eb5-bfd1-2064246c745d")
@@ -277,7 +277,7 @@ abstract class AbstractAuthHandlerIntegrationTests() {
     @Test
     fun `Test if get claims works with email address`() {
         val token = "eyJraWQiOiJwREgwTUpqeWdoRk4wT2J1cFpUNzl1QytLZkpZQ3BtNnZTamVXb3NpZUlFPSIsImFsZyI6IlJTMjU2In0.eyJzdWIiOiI3NTUzZGRmOC1hMTAzLTRjYjItOWVkZi0yNDcwMTBmNGNjNGQiLCJhdWQiOiIzdjRzNm9lMmRobjZua2hydTU3OWc2bTZnMSIsImNvZ25pdG86Z3JvdXBzIjpbIlJPTEVfUEFUSUVOVCJdLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImV2ZW50X2lkIjoiZmMxNTM3NTQtNDY5ZS00YzZiLTlhMzktODVhM2M3MDAxZTMwIiwidG9rZW5fdXNlIjoiaWQiLCJhdXRoX3RpbWUiOjE1OTk1NjY5MjMsImlzcyI6Imh0dHBzOlwvXC9jb2duaXRvLWlkcC5ldS1jZW50cmFsLTEuYW1hem9uYXdzLmNvbVwvZXUtY2VudHJhbC0xX0MxR243SGJZTiIsImNvZ25pdG86dXNlcm5hbWUiOiI2YTg0MzYzNS1kZWM2LTQxMmYtYjI0MS1iNGRmYmI2NTVkM2YiLCJleHAiOjE1OTk1NzA1MjMsImlhdCI6MTU5OTU2NjkyMywiZW1haWwiOiJnYWViZWxAbGlmdHJpYy5jb20ifQ.ka1nCmT-ACwbvQ3uy3qsuZII6PQzdfJHA7UY3Wkt_7GU2fxBxcDdRjzdDdCmh4IE0e0uwfoddMXTXWaijo6yKvrv0VHtfsIkfFJb09TNtCNrxTy1PX-bJNeVT752N85pdNpkms6GefylP2iAZec520ISI1ZrHz0jlKfUq6iGpq3GKxIXJZ_dQGVPa2oTQDqG_CmOsr9sTRl8EoMoEIjxJdOAFeYltlPDcuhWZVUWsfwUq290UdOTBJhGruIre-cdfe03FEo9NG67mewldRYdsjNBgGQU_Jyp68hg1UQHrhKC-eUDmrWiyYGzKwbkUCCm1puwcy_wpu5HRQfjAjVW4A"
-        authHandler.getClaims(token)
+        authHandler.idTokenPayload(token)
             .onSuccess { claims ->
                 assertNotNull(claims)
                 assertEquals(claims.sub, "7553ddf8-a103-4cb2-9edf-247010f4cc4d")

--- a/auth/src/commonTest/kotlin/com/liftric/auth/AuthHandlerIntegrationTests.kt
+++ b/auth/src/commonTest/kotlin/com/liftric/auth/AuthHandlerIntegrationTests.kt
@@ -278,16 +278,6 @@ abstract class AbstractAuthHandlerIntegrationTests() {
         assertEquals(idToken.claims.emailVerified, false)
     }
 
-    @JsName("GetClaimsWithEmailTest")
-    @Test
-    fun `Test if get claims works with email address`() {
-        val token = "eyJraWQiOiJwREgwTUpqeWdoRk4wT2J1cFpUNzl1QytLZkpZQ3BtNnZTamVXb3NpZUlFPSIsImFsZyI6IlJTMjU2In0.eyJzdWIiOiI3NTUzZGRmOC1hMTAzLTRjYjItOWVkZi0yNDcwMTBmNGNjNGQiLCJhdWQiOiIzdjRzNm9lMmRobjZua2hydTU3OWc2bTZnMSIsImNvZ25pdG86Z3JvdXBzIjpbIlJPTEVfUEFUSUVOVCJdLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImV2ZW50X2lkIjoiZmMxNTM3NTQtNDY5ZS00YzZiLTlhMzktODVhM2M3MDAxZTMwIiwidG9rZW5fdXNlIjoiaWQiLCJhdXRoX3RpbWUiOjE1OTk1NjY5MjMsImlzcyI6Imh0dHBzOlwvXC9jb2duaXRvLWlkcC5ldS1jZW50cmFsLTEuYW1hem9uYXdzLmNvbVwvZXUtY2VudHJhbC0xX0MxR243SGJZTiIsImNvZ25pdG86dXNlcm5hbWUiOiI2YTg0MzYzNS1kZWM2LTQxMmYtYjI0MS1iNGRmYmI2NTVkM2YiLCJleHAiOjE1OTk1NzA1MjMsImlhdCI6MTU5OTU2NjkyMywiZW1haWwiOiJnYWViZWxAbGlmdHJpYy5jb20ifQ.ka1nCmT-ACwbvQ3uy3qsuZII6PQzdfJHA7UY3Wkt_7GU2fxBxcDdRjzdDdCmh4IE0e0uwfoddMXTXWaijo6yKvrv0VHtfsIkfFJb09TNtCNrxTy1PX-bJNeVT752N85pdNpkms6GefylP2iAZec520ISI1ZrHz0jlKfUq6iGpq3GKxIXJZ_dQGVPa2oTQDqG_CmOsr9sTRl8EoMoEIjxJdOAFeYltlPDcuhWZVUWsfwUq290UdOTBJhGruIre-cdfe03FEo9NG67mewldRYdsjNBgGQU_Jyp68hg1UQHrhKC-eUDmrWiyYGzKwbkUCCm1puwcy_wpu5HRQfjAjVW4A"
-        val idToken = CognitoIdToken(token)
-        assertEquals(idToken.claims.sub, "7553ddf8-a103-4cb2-9edf-247010f4cc4d")
-        assertNotEquals(idToken.claims.email, null)
-        assertEquals(idToken.claims.emailVerified, false)
-    }
-
     @JsName("GetCustomAttributes")
     @Test
     fun `Test if gets custom attributes`() {

--- a/auth/src/iosMain/kotlin/com/liftric/auth/jwt/Base64.kt
+++ b/auth/src/iosMain/kotlin/com/liftric/auth/jwt/Base64.kt
@@ -1,4 +1,4 @@
-package com.liftric.auth.base
+package com.liftric.auth.jwt
 
 import platform.Foundation.NSData
 import platform.Foundation.NSString


### PR DESCRIPTION
Both the id token and the access token are now serializable. The objects have been constructed in conformance to the OIDC standard and the IETS specification. The custom serializer takes care that the possible custom attributes of the id token get deserialized into the 'custom' map. 

~~The JWT tokens can be decoded via the new 'idTokenPayload' and/or 'accessTokenPayload' methods.~~

~~Both objects have a 'toJsonString' method which encodes the object back to a JSON string.~~

~~Important: The implementation hasn't been tested yet~~ 