### PR TITLE
feat: npm publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: set up JDK 1.8
+      - name: set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Build and test (Android & Js)
         run: region=${{ secrets.region }} clientid=${{ secrets.clientid }} ./gradlew build allTest
       - name: Upload test result

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           java-version: 1.8
       - name: Build and test (Android & Js)
-        run: export origin=${{ secrets.origin }}; export clientid=${{ secrets.clientid }}; ./gradlew build allTest
+        run: region=${{ secrets.region }} clientid=${{ secrets.clientid }} ./gradlew build allTest
       - name: Upload test result
         if: ${{ always() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Grant Permission to Execute
         run: chmod +x gradlew
       - name: New version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,4 +24,4 @@ jobs:
           ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.OSSRH_USERNAME }}
           ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.OSSRH_PASSWORD }}
           ORG_GRADLE_PROJECT_npmAccessKey: ${{ secrets.NPMJS_ACCESS_KEY }}
-        run: ./gradlew publishAllPublicationsToSonatypeRepository
+        run: ./gradlew publishAllPublicationsToSonatypeRepository publishJsNpmPublicationToNpmjs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,4 +23,5 @@ jobs:
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
           ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.OSSRH_USERNAME }}
           ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.OSSRH_PASSWORD }}
+          ORG_GRADLE_PROJECT_npmAccessKey: ${{ secrets.NPMJS_ACCESS_KEY }}
         run: ./gradlew publishAllPublicationsToSonatypeRepository

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-![CI](https://github.com/Liftric/auth/workflows/CI/badge.svg) ![maven-central](https://img.shields.io/maven-central/v/com.liftric/auth)
+![CI](https://github.com/Liftric/auth/workflows/CI/badge.svg) 
+![maven-central](https://img.shields.io/maven-central/v/com.liftric/auth) 
+![npm (scoped)](https://img.shields.io/npm/v/@liftric/auth)
 
 # Auth
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ sourceSets {
 ```
 
 ### Typescript
-TODO
+```
+yarn add @liftric/auth@<version>
+[OR]
+npm i @liftric/auth@<version>
+```
 
 ## How-to
 
@@ -31,11 +35,10 @@ TODO
 
 At first you have to instantiate the dependencies for the authentication handler class.
 
-The handler needs a configuration object consisting of the origin url, the region code, and the client ID.
+The handler needs a configuration object consisting of the region code and the client ID.
 
 ```kotlin
-val configuration = Configuration(origin = "ORIGIN_URL",  
-                                  region = Region.euCentral1,
+val configuration = Configuration(region = Region.euCentral1,
                                   clientId = "CLIENT_ID") 
 ```
 
@@ -43,6 +46,14 @@ Now you have to pass the configuration object to the authentication handler via 
 
 ```kotlin
 val authHandler = AuthHandler(configuration) 
+```
+
+#### Instantiating - Typescript
+
+```typescript
+import {AuthHandlerJS} from '@liftric/auth';
+
+const auth = new AuthHandlerJS('<regionString>', '<clientId>');
 ```
 
 ### API
@@ -204,10 +215,10 @@ deleteUser(accessToken = "TOKEN_FROM_SIGN_IN_REQUEST"): Result<Unit>
 Auth is a simple kotlin project with one caveat: We're using a live Cogntio Userpool for integration tests and 
 the values are provided using code generation at compile time. 
 
-The build needs both `origin` and `clientid` configured, either using our hashicorp vault cluster (obviously not accessible from the outside),
-or via env var (github actions approach).
+The build needs both `region` and `clientid` configured, either using our hashicorp vault cluster (obviously not accessible from the outside),
+or via env var (github actions approach). `region` expects the AWS Region Code for the target region, like "us-east-1".
 
-So if you only want to build the project, provide `origin` and `clientid` env var with garbage values...
+So if you only want to build the project, provide `region` and `clientid` env var with garbage values...
 
 ... and if you want to execute to tests yourself, you can use your own congito user pool client values.
 

--- a/auth/build.gradle.kts
+++ b/auth/build.gradle.kts
@@ -26,6 +26,11 @@ plugins {
     id("com.liftric.vault-client-plugin") version "2.0.0"
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 repositories {
     mavenCentral()
     google()
@@ -186,6 +191,7 @@ tasks {
 
     withType<KotlinCompile> {
         kotlinOptions {
+            jvmTarget = "1.8"
             languageVersion = "1.5"
             freeCompilerArgs = listOf(
                 "-Xinline-classes",

--- a/auth/src/commonMain/kotlin/com/liftric/auth/Configuration.kt
+++ b/auth/src/commonMain/kotlin/com/liftric/auth/Configuration.kt
@@ -8,7 +8,15 @@ import io.ktor.http.HeadersBuilder
  * Configuration object for the auth handler
  * Holds all headers needed to make requests to AWS Cognito
  */
-class Configuration(origin: String, region: Region, val clientId: String) {
+class Configuration(region: Region, val clientId: String) {
+
+    /**
+     * For compatibility reasons this constructor is needed, previous Auth versions set the Origin header
+     */
+    constructor(origin: String, region: Region, clientId: String) : this(region,clientId) {
+        println("Configuration: origin isn't required, please adapt to the primary constructor")
+    }
+
     internal val requestUrl = "https://cognito-idp.${region.code}.amazonaws.com"
 
     private val headers = mapOf(
@@ -17,10 +25,8 @@ class Configuration(origin: String, region: Region, val clientId: String) {
         Header.AmzUserAgent to "aws-amplify/0.1.x js",
         Header.Useragent to "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36",
         Header.Accept to "*/*",
-        Header.Origin to origin,
         Header.SecFetchSite to "cross-site",
         Header.SecFetchMode to "cors",
-        Header.SecFetchDest to "${origin}/auth/(modal:login)",
         Header.AcceptLanguage to "de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7,cs;q=0.6,es;q=0.5,da;q=0.4,ru;q=0.3",
         Header.Dnt to "1"
     )

--- a/auth/src/commonMain/kotlin/com/liftric/auth/Configuration.kt
+++ b/auth/src/commonMain/kotlin/com/liftric/auth/Configuration.kt
@@ -13,6 +13,7 @@ class Configuration(region: Region, val clientId: String) {
     /**
      * For compatibility reasons this constructor is needed, previous Auth versions set the Origin header
      */
+    @Deprecated("origin isn't required, please adapt to the primary constructor")
     constructor(origin: String, region: Region, clientId: String) : this(region,clientId) {
         println("Configuration: origin isn't required, please adapt to the primary constructor")
     }

--- a/auth/src/commonMain/kotlin/com/liftric/auth/base/Constants.kt
+++ b/auth/src/commonMain/kotlin/com/liftric/auth/base/Constants.kt
@@ -6,10 +6,8 @@ object Header {
     const val AmzUserAgent      = "x-amz-user-agent"
     const val Useragent         = "user-agent"
     const val Accept            = "accept"
-    const val Origin            = "origin"
     const val SecFetchSite      = "sec-fetch-site"
     const val SecFetchMode      = "sec-fetch-mode"
-    const val SecFetchDest      = "sec-fetch-dest"
     const val AcceptLanguage    = "accept-language"
     const val Dnt               = "dnt"
     const val AmzTarget         = "x-amz-target"
@@ -22,6 +20,9 @@ object AuthFlow {
     const val UserPasswordAuth  = "USER_PASSWORD_AUTH"
 }
 
+/**
+ * @see https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints
+ */
 enum class Region(val code: String) {
     usEast1("us-east-1"),
     usEast2("us-east-2"),

--- a/auth/src/commonTest/kotlin/com/liftric/auth/AuthHandlerIntegrationTests.kt
+++ b/auth/src/commonTest/kotlin/com/liftric/auth/AuthHandlerIntegrationTests.kt
@@ -12,12 +12,11 @@ import kotlin.test.*
 
 expect fun runTest(block: suspend () -> Unit)
 
-expect class AuthHandlerIntegrationTests: AbstractAuthHandlerIntegrationTests
+expect class AuthHandlerIntegrationTests : AbstractAuthHandlerIntegrationTests
 abstract class AbstractAuthHandlerIntegrationTests() {
     private val configuration = Configuration(
-        env["origin"] ?: "",
-        Region.euCentral1,
-        env["clientid"] ?: ""
+        Region.values().first { it.code == (env["region"] ?: error("region env missing")) },
+        env["clientid"] ?: error("clientid env missing")
     )
 
     // Randomize temp user account name to not exceed aws try threshold
@@ -311,7 +310,8 @@ abstract class AbstractAuthHandlerIntegrationTests() {
     @JsName("TestGetIdTokenClaimsWithEmailNullValue")
     @Test
     fun `Test if get id token  claims works without email address`() {
-        val token = "eyJraWQiOiJwREgwTUpqeWdoRk4wT2J1cFpUNzl1QytLZkpZQ3BtNnZTamVXb3NpZUlFPSIsImFsZyI6IlJTMjU2In0.eyJzdWIiOiIxZWEyMTg1Yi1iYTk5LTRlYjUtYmZkMS0yMDY0MjQ2Yzc0NWQiLCJhdWQiOiIzdjRzNm9lMmRobjZua2hydTU3OWc2bTZnMSIsImNvZ25pdG86Z3JvdXBzIjpbIlJPTEVfUEFUSUVOVCJdLCJldmVudF9pZCI6IjA3ODE5NGUzLTM5YzQtNDBhYS04MzkwLTkzMmI2MjY2MjE3YSIsInRva2VuX3VzZSI6ImlkIiwiYXV0aF90aW1lIjoxNTk5NTY1OTU4LCJpc3MiOiJodHRwczpcL1wvY29nbml0by1pZHAuZXUtY2VudHJhbC0xLmFtYXpvbmF3cy5jb21cL2V1LWNlbnRyYWwtMV9DMUduN0hiWU4iLCJjb2duaXRvOnVzZXJuYW1lIjoiNDMzMGI4ZjctYmRjMy00MTI2LTllYWUtZWVkZTc0ZTI0MTEyIiwiZXhwIjoxNTk5NTY5NTU4LCJpYXQiOjE1OTk1NjU5NTh9.hLzDOItbHkUWYyI9hTFIKkoC50_UrRnPFoIcyrsiCzP5zQFlhTboe9TZ6BE0o21IEk8tcdBkFRHbuM8zPru-qopB9tC7pkhvY1FoPMlNlRSmqj8YZjJ8InnHForkdJ4n9keM8PcdwW6KWlAjLViwSmOl3k-ptQq1DnmnmGmcmfzssDzON0R__jsyEQs_EZWQ3c86qodbIU4peN9Dm26TMSQCzJhZwvCuGRmRgplsqOD4UfDVh5ya-bXUogJuirlE8KFUH1my13AJOxAJLBgyOjBZceFMnC4ZqZBbSND-iiMvQcpn4O6gd5p5Je367LO56w_ypo6eMffEs39fikIP4g"
+        val token =
+            "eyJraWQiOiJwREgwTUpqeWdoRk4wT2J1cFpUNzl1QytLZkpZQ3BtNnZTamVXb3NpZUlFPSIsImFsZyI6IlJTMjU2In0.eyJzdWIiOiIxZWEyMTg1Yi1iYTk5LTRlYjUtYmZkMS0yMDY0MjQ2Yzc0NWQiLCJhdWQiOiIzdjRzNm9lMmRobjZua2hydTU3OWc2bTZnMSIsImNvZ25pdG86Z3JvdXBzIjpbIlJPTEVfUEFUSUVOVCJdLCJldmVudF9pZCI6IjA3ODE5NGUzLTM5YzQtNDBhYS04MzkwLTkzMmI2MjY2MjE3YSIsInRva2VuX3VzZSI6ImlkIiwiYXV0aF90aW1lIjoxNTk5NTY1OTU4LCJpc3MiOiJodHRwczpcL1wvY29nbml0by1pZHAuZXUtY2VudHJhbC0xLmFtYXpvbmF3cy5jb21cL2V1LWNlbnRyYWwtMV9DMUduN0hiWU4iLCJjb2duaXRvOnVzZXJuYW1lIjoiNDMzMGI4ZjctYmRjMy00MTI2LTllYWUtZWVkZTc0ZTI0MTEyIiwiZXhwIjoxNTk5NTY5NTU4LCJpYXQiOjE1OTk1NjU5NTh9.hLzDOItbHkUWYyI9hTFIKkoC50_UrRnPFoIcyrsiCzP5zQFlhTboe9TZ6BE0o21IEk8tcdBkFRHbuM8zPru-qopB9tC7pkhvY1FoPMlNlRSmqj8YZjJ8InnHForkdJ4n9keM8PcdwW6KWlAjLViwSmOl3k-ptQq1DnmnmGmcmfzssDzON0R__jsyEQs_EZWQ3c86qodbIU4peN9Dm26TMSQCzJhZwvCuGRmRgplsqOD4UfDVh5ya-bXUogJuirlE8KFUH1my13AJOxAJLBgyOjBZceFMnC4ZqZBbSND-iiMvQcpn4O6gd5p5Je367LO56w_ypo6eMffEs39fikIP4g"
         val idToken = CognitoIdToken(token)
         assertEquals(idToken.claims.sub, "1ea2185b-ba99-4eb5-bfd1-2064246c745d")
         assertEquals(idToken.claims.email, null)
@@ -321,7 +321,8 @@ abstract class AbstractAuthHandlerIntegrationTests() {
     @JsName("TestGetIdTokenClaimsWithEmail")
     @Test
     fun `Test if get id token claims works with email address`() {
-        val token = "eyJraWQiOiJwREgwTUpqeWdoRk4wT2J1cFpUNzl1QytLZkpZQ3BtNnZTamVXb3NpZUlFPSIsImFsZyI6IlJTMjU2In0.eyJzdWIiOiI3NTUzZGRmOC1hMTAzLTRjYjItOWVkZi0yNDcwMTBmNGNjNGQiLCJhdWQiOiIzdjRzNm9lMmRobjZua2hydTU3OWc2bTZnMSIsImNvZ25pdG86Z3JvdXBzIjpbIlJPTEVfUEFUSUVOVCJdLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImV2ZW50X2lkIjoiZmMxNTM3NTQtNDY5ZS00YzZiLTlhMzktODVhM2M3MDAxZTMwIiwidG9rZW5fdXNlIjoiaWQiLCJhdXRoX3RpbWUiOjE1OTk1NjY5MjMsImlzcyI6Imh0dHBzOlwvXC9jb2duaXRvLWlkcC5ldS1jZW50cmFsLTEuYW1hem9uYXdzLmNvbVwvZXUtY2VudHJhbC0xX0MxR243SGJZTiIsImNvZ25pdG86dXNlcm5hbWUiOiI2YTg0MzYzNS1kZWM2LTQxMmYtYjI0MS1iNGRmYmI2NTVkM2YiLCJleHAiOjE1OTk1NzA1MjMsImlhdCI6MTU5OTU2NjkyMywiZW1haWwiOiJnYWViZWxAbGlmdHJpYy5jb20ifQ.ka1nCmT-ACwbvQ3uy3qsuZII6PQzdfJHA7UY3Wkt_7GU2fxBxcDdRjzdDdCmh4IE0e0uwfoddMXTXWaijo6yKvrv0VHtfsIkfFJb09TNtCNrxTy1PX-bJNeVT752N85pdNpkms6GefylP2iAZec520ISI1ZrHz0jlKfUq6iGpq3GKxIXJZ_dQGVPa2oTQDqG_CmOsr9sTRl8EoMoEIjxJdOAFeYltlPDcuhWZVUWsfwUq290UdOTBJhGruIre-cdfe03FEo9NG67mewldRYdsjNBgGQU_Jyp68hg1UQHrhKC-eUDmrWiyYGzKwbkUCCm1puwcy_wpu5HRQfjAjVW4A"
+        val token =
+            "eyJraWQiOiJwREgwTUpqeWdoRk4wT2J1cFpUNzl1QytLZkpZQ3BtNnZTamVXb3NpZUlFPSIsImFsZyI6IlJTMjU2In0.eyJzdWIiOiI3NTUzZGRmOC1hMTAzLTRjYjItOWVkZi0yNDcwMTBmNGNjNGQiLCJhdWQiOiIzdjRzNm9lMmRobjZua2hydTU3OWc2bTZnMSIsImNvZ25pdG86Z3JvdXBzIjpbIlJPTEVfUEFUSUVOVCJdLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImV2ZW50X2lkIjoiZmMxNTM3NTQtNDY5ZS00YzZiLTlhMzktODVhM2M3MDAxZTMwIiwidG9rZW5fdXNlIjoiaWQiLCJhdXRoX3RpbWUiOjE1OTk1NjY5MjMsImlzcyI6Imh0dHBzOlwvXC9jb2duaXRvLWlkcC5ldS1jZW50cmFsLTEuYW1hem9uYXdzLmNvbVwvZXUtY2VudHJhbC0xX0MxR243SGJZTiIsImNvZ25pdG86dXNlcm5hbWUiOiI2YTg0MzYzNS1kZWM2LTQxMmYtYjI0MS1iNGRmYmI2NTVkM2YiLCJleHAiOjE1OTk1NzA1MjMsImlhdCI6MTU5OTU2NjkyMywiZW1haWwiOiJnYWViZWxAbGlmdHJpYy5jb20ifQ.ka1nCmT-ACwbvQ3uy3qsuZII6PQzdfJHA7UY3Wkt_7GU2fxBxcDdRjzdDdCmh4IE0e0uwfoddMXTXWaijo6yKvrv0VHtfsIkfFJb09TNtCNrxTy1PX-bJNeVT752N85pdNpkms6GefylP2iAZec520ISI1ZrHz0jlKfUq6iGpq3GKxIXJZ_dQGVPa2oTQDqG_CmOsr9sTRl8EoMoEIjxJdOAFeYltlPDcuhWZVUWsfwUq290UdOTBJhGruIre-cdfe03FEo9NG67mewldRYdsjNBgGQU_Jyp68hg1UQHrhKC-eUDmrWiyYGzKwbkUCCm1puwcy_wpu5HRQfjAjVW4A"
         val idToken = CognitoIdToken(token)
         assertEquals(idToken.claims.sub, "7553ddf8-a103-4cb2-9edf-247010f4cc4d")
         assertNotEquals(idToken.claims.email, null)
@@ -331,7 +332,8 @@ abstract class AbstractAuthHandlerIntegrationTests() {
     @JsName("GetCustomAttributes")
     @Test
     fun `Test if custom attributes get mapped correctly`() {
-        val token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI3NTUzZGRmOC1hMTAzLTRjYjItOWVkZi0yNDcwMTBmNGNjNGQiLCJhdWQiOiIzdjRzNm9lMmRobjZua2hydTU3OWc2bTZnMSIsImNvZ25pdG86Z3JvdXBzIjpbIlJPTEVfUEFUSUVOVCJdLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImV2ZW50X2lkIjoiZmMxNTM3NTQtNDY5ZS00YzZiLTlhMzktODVhM2M3MDAxZTMwIiwidG9rZW5fdXNlIjoiaWQiLCJhdXRoX3RpbWUiOjE1OTk1NjY5MjMsImlzcyI6Imh0dHBzOi8vY29nbml0by1pZHAuZXUtY2VudHJhbC0xLmFtYXpvbmF3cy5jb20vZXUtY2VudHJhbC0xX0MxR243SGJZTiIsImNvZ25pdG86dXNlcm5hbWUiOiI2YTg0MzYzNS1kZWM2LTQxMmYtYjI0MS1iNGRmYmI2NTVkM2YiLCJleHAiOjE2MDEzMDE1ODYsImlhdCI6MTU5OTU2NjkyMywiZW1haWwiOiJ0ZXN0QHRlc3QuY29tIiwiY3VzdG9tOnR3aXR0ZXIiOiJ0ZXN0IiwiY3VzdG9tOmFnZSI6MTgsImp0aSI6ImI0NjE2MzZmLWUxOGMtNDhjZi04Mjk5LTUzYjZmMWIxNWZmMyJ9.Mzh2RGW1VWd1oxE89xW05Ce_JRs1Y2HifL3brBkf7NE"
+        val token =
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI3NTUzZGRmOC1hMTAzLTRjYjItOWVkZi0yNDcwMTBmNGNjNGQiLCJhdWQiOiIzdjRzNm9lMmRobjZua2hydTU3OWc2bTZnMSIsImNvZ25pdG86Z3JvdXBzIjpbIlJPTEVfUEFUSUVOVCJdLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImV2ZW50X2lkIjoiZmMxNTM3NTQtNDY5ZS00YzZiLTlhMzktODVhM2M3MDAxZTMwIiwidG9rZW5fdXNlIjoiaWQiLCJhdXRoX3RpbWUiOjE1OTk1NjY5MjMsImlzcyI6Imh0dHBzOi8vY29nbml0by1pZHAuZXUtY2VudHJhbC0xLmFtYXpvbmF3cy5jb20vZXUtY2VudHJhbC0xX0MxR243SGJZTiIsImNvZ25pdG86dXNlcm5hbWUiOiI2YTg0MzYzNS1kZWM2LTQxMmYtYjI0MS1iNGRmYmI2NTVkM2YiLCJleHAiOjE2MDEzMDE1ODYsImlhdCI6MTU5OTU2NjkyMywiZW1haWwiOiJ0ZXN0QHRlc3QuY29tIiwiY3VzdG9tOnR3aXR0ZXIiOiJ0ZXN0IiwiY3VzdG9tOmFnZSI6MTgsImp0aSI6ImI0NjE2MzZmLWUxOGMtNDhjZi04Mjk5LTUzYjZmMWIxNWZmMyJ9.Mzh2RGW1VWd1oxE89xW05Ce_JRs1Y2HifL3brBkf7NE"
         val idToken = CognitoIdToken(token)
         assertNotNull(idToken.claims.customAttributes?.get("custom:age"))
         assertNotNull(idToken.claims.customAttributes?.get("custom:twitter"))
@@ -342,7 +344,8 @@ abstract class AbstractAuthHandlerIntegrationTests() {
     @JsName("TestGetAccessTokenClaims")
     @Test
     fun `Test if get access token claims`() {
-        val token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhYWFhYWFhYS1iYmJiLWNjY2MtZGRkZC1lZWVlZWVlZWVlZWUiLCJkZXZpY2Vfa2V5IjoiYWFhYWFhYWEtYmJiYi1jY2NjLWRkZGQtZWVlZWVlZWVlZWVlIiwiY29nbml0bzpncm91cHMiOlsiYWRtaW4iXSwidG9rZW5fdXNlIjoiYWNjZXNzIiwic2NvcGUiOiJhd3MuY29nbml0by5zaWduaW4udXNlci5hZG1pbiIsImF1dGhfdGltZSI6MTU2MjE5MDUyNCwiaXNzIjoiaHR0cHM6Ly9jb2duaXRvLWlkcC51cy13ZXN0LTIuYW1hem9uYXdzLmNvbS91cy13ZXN0LTJfZXhhbXBsZSIsImV4cCI6MTYwMTI5ODY0MiwiaWF0IjoxNTYyMTkwNTI0LCJqdGkiOiJhYWFhYWFhYS1iYmJiLWNjY2MtZGRkZC1lZWVlZWVlZWVlZWUiLCJjbGllbnRfaWQiOiI1N2NiaXNoazRqMjRwYWJjMTIzNDU2Nzg5MCIsInVzZXJuYW1lIjoiamFuZWRvZUBleGFtcGxlLmNvbSJ9.AYrQOiqkjy6XyF33jAYje-hVfX5OnuiYUhh8pS1wxBk"
+        val token =
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhYWFhYWFhYS1iYmJiLWNjY2MtZGRkZC1lZWVlZWVlZWVlZWUiLCJkZXZpY2Vfa2V5IjoiYWFhYWFhYWEtYmJiYi1jY2NjLWRkZGQtZWVlZWVlZWVlZWVlIiwiY29nbml0bzpncm91cHMiOlsiYWRtaW4iXSwidG9rZW5fdXNlIjoiYWNjZXNzIiwic2NvcGUiOiJhd3MuY29nbml0by5zaWduaW4udXNlci5hZG1pbiIsImF1dGhfdGltZSI6MTU2MjE5MDUyNCwiaXNzIjoiaHR0cHM6Ly9jb2duaXRvLWlkcC51cy13ZXN0LTIuYW1hem9uYXdzLmNvbS91cy13ZXN0LTJfZXhhbXBsZSIsImV4cCI6MTYwMTI5ODY0MiwiaWF0IjoxNTYyMTkwNTI0LCJqdGkiOiJhYWFhYWFhYS1iYmJiLWNjY2MtZGRkZC1lZWVlZWVlZWVlZWUiLCJjbGllbnRfaWQiOiI1N2NiaXNoazRqMjRwYWJjMTIzNDU2Nzg5MCIsInVzZXJuYW1lIjoiamFuZWRvZUBleGFtcGxlLmNvbSJ9.AYrQOiqkjy6XyF33jAYje-hVfX5OnuiYUhh8pS1wxBk"
         val accessToken = CognitoAccessToken(token)
         assertEquals(accessToken.claims.sub, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
         assertEquals(accessToken.claims.deviceKey, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
@@ -372,7 +375,8 @@ abstract class AbstractAuthHandlerIntegrationTests() {
     @Test
     fun `Test should throw InvalidBase64Exception since it is not a base 64 encoded string`() {
         assertFailsWith(InvalidBase64Exception::class) {
-            val token = "component.EOKF36syRBtB11VgyChkNjc1HxRrajT7XXaxZfnVzPkV57K3b9yqkS284Ovb9uWzXgGeY2bxA3IySGfdOHiPAQ==F/v6hcTiU1sd975XHfDsz8o0rboujM77n7KwRMidobOLbo5ghUT/IFcxElUc8CirdZxaCaS3zs/CfRKRsXwbFNYd.component"
+            val token =
+                "component.EOKF36syRBtB11VgyChkNjc1HxRrajT7XXaxZfnVzPkV57K3b9yqkS284Ovb9uWzXgGeY2bxA3IySGfdOHiPAQ==F/v6hcTiU1sd975XHfDsz8o0rboujM77n7KwRMidobOLbo5ghUT/IFcxElUc8CirdZxaCaS3zs/CfRKRsXwbFNYd.component"
             val idToken = CognitoIdToken(token)
             idToken.getPayload()
         }
@@ -382,7 +386,8 @@ abstract class AbstractAuthHandlerIntegrationTests() {
     @Test
     fun `Test should throw InvalidCognitoIdTokenException since this is not a valid Cognito Id token`() {
         assertFailsWith(InvalidCognitoIdTokenException::class) {
-            val token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiIzdjRzNm9lMmRobjZua2hydTU3OWc2bTZnMSIsImNvZ25pdG86Z3JvdXBzIjpbIlJPTEVfUEFUSUVOVCJdLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImV2ZW50X2lkIjoiZmMxNTM3NTQtNDY5ZS00YzZiLTlhMzktODVhM2M3MDAxZTMwIiwidG9rZW5fdXNlIjoiaWQiLCJhdXRoX3RpbWUiOjE1OTk1NjY5MjMsImNvZ25pdG86dXNlcm5hbWUiOiI2YTg0MzYzNS1kZWM2LTQxMmYtYjI0MS1iNGRmYmI2NTVkM2YiLCJleHAiOjE2MDEyOTQ1NDQsImlhdCI6MTU5OTU2NjkyMywiZW1haWxfd2l0aF90eXBvIjoiZ2FlYmVsQGxpZnRyaWMuY29tIiwianRpIjoiYWNkNjg1MTUtZmExZi00ZTNmLWI3ZmUtODEwYzY2NmRhODYwIn0.zuqwEPXiLzbmxSdNQGjr3m4X5cXqdQf4aw_-7BUbvZk"
+            val token =
+                "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiIzdjRzNm9lMmRobjZua2hydTU3OWc2bTZnMSIsImNvZ25pdG86Z3JvdXBzIjpbIlJPTEVfUEFUSUVOVCJdLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImV2ZW50X2lkIjoiZmMxNTM3NTQtNDY5ZS00YzZiLTlhMzktODVhM2M3MDAxZTMwIiwidG9rZW5fdXNlIjoiaWQiLCJhdXRoX3RpbWUiOjE1OTk1NjY5MjMsImNvZ25pdG86dXNlcm5hbWUiOiI2YTg0MzYzNS1kZWM2LTQxMmYtYjI0MS1iNGRmYmI2NTVkM2YiLCJleHAiOjE2MDEyOTQ1NDQsImlhdCI6MTU5OTU2NjkyMywiZW1haWxfd2l0aF90eXBvIjoiZ2FlYmVsQGxpZnRyaWMuY29tIiwianRpIjoiYWNkNjg1MTUtZmExZi00ZTNmLWI3ZmUtODEwYzY2NmRhODYwIn0.zuqwEPXiLzbmxSdNQGjr3m4X5cXqdQf4aw_-7BUbvZk"
             val idToken = CognitoIdToken(token)
             idToken.claims
         }
@@ -392,7 +397,8 @@ abstract class AbstractAuthHandlerIntegrationTests() {
     @Test
     fun `Test should throw InvalidCognitoAccessTokenException since this is not a valid Cognito Access token`() {
         assertFailsWith(InvalidCognitoAccessTokenException::class) {
-            val token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiIzdjRzNm9lMmRobjZua2hydTU3OWc2bTZnMSIsImNvZ25pdG86Z3JvdXBzIjpbIlJPTEVfUEFUSUVOVCJdLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImV2ZW50X2lkIjoiZmMxNTM3NTQtNDY5ZS00YzZiLTlhMzktODVhM2M3MDAxZTMwIiwidG9rZW5fdXNlIjoiaWQiLCJhdXRoX3RpbWUiOjE1OTk1NjY5MjMsImNvZ25pdG86dXNlcm5hbWUiOiI2YTg0MzYzNS1kZWM2LTQxMmYtYjI0MS1iNGRmYmI2NTVkM2YiLCJleHAiOjE2MDEyOTQ1NDQsImlhdCI6MTU5OTU2NjkyMywiZW1haWxfd2l0aF90eXBvIjoiZ2FlYmVsQGxpZnRyaWMuY29tIiwianRpIjoiYWNkNjg1MTUtZmExZi00ZTNmLWI3ZmUtODEwYzY2NmRhODYwIn0.zuqwEPXiLzbmxSdNQGjr3m4X5cXqdQf4aw_-7BUbvZk"
+            val token =
+                "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiIzdjRzNm9lMmRobjZua2hydTU3OWc2bTZnMSIsImNvZ25pdG86Z3JvdXBzIjpbIlJPTEVfUEFUSUVOVCJdLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsImV2ZW50X2lkIjoiZmMxNTM3NTQtNDY5ZS00YzZiLTlhMzktODVhM2M3MDAxZTMwIiwidG9rZW5fdXNlIjoiaWQiLCJhdXRoX3RpbWUiOjE1OTk1NjY5MjMsImNvZ25pdG86dXNlcm5hbWUiOiI2YTg0MzYzNS1kZWM2LTQxMmYtYjI0MS1iNGRmYmI2NTVkM2YiLCJleHAiOjE2MDEyOTQ1NDQsImlhdCI6MTU5OTU2NjkyMywiZW1haWxfd2l0aF90eXBvIjoiZ2FlYmVsQGxpZnRyaWMuY29tIiwianRpIjoiYWNkNjg1MTUtZmExZi00ZTNmLWI3ZmUtODEwYzY2NmRhODYwIn0.zuqwEPXiLzbmxSdNQGjr3m4X5cXqdQf4aw_-7BUbvZk"
             val accessToken = CognitoAccessToken(token)
             accessToken.claims
         }

--- a/auth/src/jsMain/kotlin/AuthHandlerJS.kt
+++ b/auth/src/jsMain/kotlin/AuthHandlerJS.kt
@@ -10,9 +10,9 @@ import kotlin.js.Promise
 /**
  * Typescript compatible [AuthHandler] implementation.
  */
-class AuthHandlerJS(origin: String, regionString: String, clientId: String) {
+class AuthHandlerJS(regionString: String, clientId: String) {
     private val region = Region.values().first { it.code == regionString }
-    private val handler: AuthHandler = AuthHandler(Configuration(origin, region, clientId))
+    private val handler: AuthHandler = AuthHandler(Configuration(region, clientId))
 
     fun signUp(username: String, password: String, attributes: Array<UserAttribute>? = null): Promise<SignUpResponse> =
         MainScope().promise {

--- a/auth/src/jsTest/kotlin/com/liftric/auth/AuthHandlerJSTest.kt
+++ b/auth/src/jsTest/kotlin/com/liftric/auth/AuthHandlerJSTest.kt
@@ -12,9 +12,8 @@ import kotlin.test.fail
 
 class AuthHandlerJSTest {
     private val authHandler = AuthHandlerJS(
-        env["origin"] ?: error("missing origin"),
-        Region.euCentral1.code,
-        env["clientid"] ?: error("missing origin")
+        env["region"] ?: error("missing region"),
+        env["clientid"] ?: error("missing clientid")
     )
 
     // Randomize temp user account name to not exceed aws try threshold

--- a/buildSrc/src/main/java/Libs.kt
+++ b/buildSrc/src/main/java/Libs.kt
@@ -13,6 +13,7 @@ object Android {
 object Versions {
     const val gradle = "4.2.1"
     const val kotlin = "1.5.10"
+    const val npmPublish = "2.0.1"
     const val definitions = "4.9.1"
     const val coroutines = "1.5.0-native-mt"
     const val serialization = "1.2.1"


### PR DESCRIPTION
Also removed origin which is not needed for Cognito API interaction and made the region configurable (so tests can use cognito clients outside of eu-central-1).

The repository secrets `REGION` and `NPMJS_ACCESS_KEY` are already created, the gitlab workflows are adapted as well :+1: 

EDIT: Also switched to JDK 11 for the build process (Java 8 is still the target compilation version to keep compatibality) as the npm publish gradle plugin is build using Java 11 as target