### PR TITLE
feat(dependencies): update dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,12 @@ jobs:
     runs-on: macOS-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
       - name: set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 17
+          distribution: 'temurin'
       - name: Build and test (Android, Jvm, Js)
         run: region=${{ secrets.region }} clientId=${{ secrets.clientid }} ./gradlew build test jsTest
       - name: Build testapp and test request (iOS)
@@ -27,7 +28,7 @@ jobs:
           xcodebuild clean test -project TestApp.xcodeproj -scheme TestApp -destination "platform=iOS Simulator,OS=16.2,name=iPhone 12" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO region=${{ secrets.region }} clientId=${{ secrets.clientid }}
       - name: Upload test result
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: reports
           path: build/reports/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-      - name: set up JDK 17
+      - name: set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'temurin'
       - name: Build and test (Android, Jvm, Js)
         run: region=${{ secrets.region }} clientId=${{ secrets.clientid }} ./gradlew build test jsTest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build testapp and test request (iOS)
         run: |
           cd iostests
-          xcodebuild clean test -project TestApp.xcodeproj -scheme TestApp -destination "platform=iOS Simulator,OS=16.2,name=iPhone 12" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO region=${{ secrets.region }} clientId=${{ secrets.clientid }}
+          xcodebuild clean test -project TestApp.xcodeproj -scheme TestApp -destination "platform=iOS Simulator,OS=26.0,name=iPhone 16" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO region=${{ secrets.region }} clientId=${{ secrets.clientid }}
       - name: Upload test result
         if: ${{ always() }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,11 +8,12 @@ jobs:
     runs-on: macOS-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 17
+          distribution: 'temurin'
       - name: Grant Permission to Execute
         run: chmod +x gradlew
       - name: New version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'temurin'
       - name: Grant Permission to Execute
         run: chmod +x gradlew

--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,4 @@ DerivedData/
 !*.xcodeproj/xcshareddata/
 !*.xcworkspace/contents.xcworkspacedata
 **/xcshareddata/WorkspaceSettings.xcsettings
-kotlin-js-store/
+.kotlin/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
     kotlin("multiplatform") version libs.versions.kotlin
     alias(libs.plugins.kotlin.serialization)
     id("com.android.library") version libs.versions.android.tools.gradle
-    alias(libs.plugins.definitions)
     alias(libs.plugins.npm.publishing)
     alias(libs.plugins.versioning)
     alias(libs.plugins.vault.client)
@@ -55,6 +54,9 @@ kotlin {
         }
     }
     js(IR) {
+        compilerOptions {
+            target.set("es2015")
+        }
         generateTypeScriptDefinitions()
         browser {
             testTask {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,9 +54,7 @@ kotlin {
         }
     }
     js(IR) {
-        compilerOptions {
-            target.set("es2015")
-        }
+        binaries.library()
         generateTypeScriptDefinitions()
         browser {
             testTask {
@@ -65,7 +63,6 @@ kotlin {
                 }
             }
         }
-        binaries.library()
         compilations.all {
             compileTaskProvider.configure {
                 compilerOptions.freeCompilerArgs.add("-Xir-minimized-member-names=false")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,8 +23,8 @@ repositories {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 kotlin {
@@ -50,7 +50,7 @@ kotlin {
     }
     jvm {
         compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_11)
+            jvmTarget.set(JvmTarget.JVM_17)
         }
     }
     js(IR) {
@@ -144,8 +144,8 @@ configure<LibraryExtension> {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     testOptions {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,7 @@
 import com.android.build.gradle.LibraryExtension
 import com.liftric.vault.GetVaultSecretTask
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeSimulatorTest
 import org.jetbrains.kotlin.gradle.tasks.*
 
@@ -22,21 +24,36 @@ repositories {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
 
 kotlin {
-    ios {
+    compilerOptions {
+        languageVersion.set(KotlinVersion.KOTLIN_2_2)
+        freeCompilerArgs.addAll(
+            listOf("-Xinline-classes")
+        )
+    }
+
+    iosX64 {
+        binaries.framework()
+    }
+    iosSimulatorArm64 {
+        binaries.framework()
+    }
+    iosArm64 {
         binaries.framework()
     }
 
-    iosSimulatorArm64()
-
-    androidTarget() {
-        publishAllLibraryVariants()
+    androidTarget {
+        publishLibraryVariants("debug", "release")
     }
-    jvm()
+    jvm {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_11)
+        }
+    }
     js(IR) {
         generateTypeScriptDefinitions()
         browser {
@@ -63,7 +80,7 @@ kotlin {
             }
         }
         val commonTest by getting {
-            kotlin.srcDir("${buildDir}/gen")
+            kotlin.srcDir(layout.buildDirectory.dir("gen"))
             dependencies {
                 implementation(kotlin("test"))
                 implementation(kotlin("test-common"))
@@ -82,31 +99,22 @@ kotlin {
         }
         val androidUnitTest by getting {
             dependencies {
-                implementation(libs.roboelectric)
+                implementation(libs.robolectric)
                 implementation(kotlin("test"))
                 implementation(kotlin("test-junit"))
                 implementation(libs.androidx.test.core)
-                implementation(libs.opt.java)
+                implementation(libs.otp.java)
             }
         }
         val jvmTest by getting {
             dependencies {
                 implementation(kotlin("test"))
                 implementation(kotlin("test-junit"))
-                implementation(libs.opt.java)
+                implementation(libs.otp.java)
             }
         }
-        val iosMain by getting {
-            dependencies {
-                api(libs.ktor.client.darwin)
-            }
-        }
-        val iosTest by getting
-        val iosSimulatorArm64Main by getting {
-            dependsOn(iosMain)
-        }
-        val iosSimulatorArm64Test by getting {
-            dependsOn(iosTest)
+        iosMain.dependencies {
+            api(libs.ktor.client.darwin)
         }
         val jsMain by getting {
             dependencies {
@@ -130,9 +138,9 @@ kotlin {
 
 configure<LibraryExtension> {
     defaultConfig.apply {
-        compileSdk = 30
-        minSdkVersion(21)
-        targetSdkVersion(30)
+        compileSdk = 36
+        minSdkVersion(31)
+        targetSdkVersion(36)
         testInstrumentationRunner = "org.robolectric.RobolectricTestRunner"
     }
 
@@ -174,12 +182,12 @@ tasks {
         filter.excludeTestsMatching("com.liftric.cognito.idp.IdentityProviderClientTests")
     }
 
-    val testSecrets by creating(GetVaultSecretTask::class) {
+    val testSecrets by registering(GetVaultSecretTask::class) {
         secretPath.set("secret/apps/smartest/shared/cognito")
     }
 
-    val createJsEnvHack by creating {
-        outputs.dir("$buildDir/gen")
+    val createJsEnvHack by registering {
+        outputs.dir(layout.buildDirectory.dir("gen").get().asFile.absolutePath)
 
         if (System.getenv("region") == null || System.getenv("clientId") == null) {
             // github ci provides region and clientId envs, locally we'll use vault directly
@@ -187,13 +195,14 @@ tasks {
         }
 
         doFirst {
-            val (clientId, region) = with(testSecrets.secret.get()) {
+            val (clientId, region) = with(testSecrets.get().secret.get()) {
                 ((System.getenv("clientId") ?: this["client_id_dev"].toString()) to
                         (System.getenv("region") ?: this["client_region_dev"].toString()))
             }
 
-            mkdir("$buildDir/gen")
-            with(File("$buildDir/gen/env.kt")) {
+            val envFile = layout.buildDirectory.dir("gen/env.kt").get().asFile
+            envFile.apply {
+                parentFile.mkdirs()
                 createNewFile()
                 writeText(
                     """
@@ -211,16 +220,6 @@ tasks {
         dependsOn(createJsEnvHack)
     }
 
-    withType<KotlinCompile> {
-        kotlinOptions {
-            jvmTarget = "11"
-            languageVersion = "1.5"
-            freeCompilerArgs = listOf(
-                "-Xinline-classes"
-            )
-        }
-    }
-
     /**
      * Ugly atomicfu export hack: Coroutines core needs atomicfu-js, which generates broken d.ts entries. Excluding
      * atomicfu-js breaks the ktor client and filtering d.ts types in the IR compile is currently not possible... so let's
@@ -228,7 +227,7 @@ tasks {
      *
      * The build/js/packages/cognito-idp/kotlin/cognito-idp.d.ts file should now be without errors and usable from typescript
      */
-    val cleanTypescriptTypes by creating {
+    val cleanTypescriptTypes by registering {
         fun MutableList<String>.removeFromTill(from: String, till: String) {
             val fromIndex = indexOfFirst { it == from }
             val tillIndex = indexOfFirst { it == till }
@@ -243,7 +242,7 @@ tasks {
             }
         }
 
-        val dTsFile = file("$buildDir/js/packages/cognito-idp/kotlin/cognito-idp.d.ts")
+        val dTsFile = layout.buildDirectory.dir("js/packages/cognito-idp/kotlin/cognito-idp.d.ts").get().asFile
         inputs.file(dTsFile)
         outputs.file(dTsFile)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,5 @@
 [versions]
 # plugins
-"definitions" = "5.124.0"
 "npm-publishing" = "4.1.3"
 "vault-client" = "3.0.0"
 "versioning" = "3.1.0"
@@ -27,7 +26,6 @@
 "robolectric" = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 
 [plugins]
-"definitions" = { id = "io.github.turansky.kfc.definitions", version.ref = "definitions" }
 "kotlin-serialization" = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 "npm-publishing" = { id = "org.danilopianini.npm.publish", version.ref = "npm-publishing" }
 "vault-client" = { id = "com.liftric.vault-client-plugin", version.ref = "vault-client" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,34 @@
+[versions]
+# plugins
+"definitions" = "5.124.0"
+"npm-publishing" = "4.1.3"
+"vault-client" = "3.0.0"
+"versioning" = "3.1.0"
+# dependencies
+"android-tools-gradle" = "8.13.0"
+"kotlin" = "2.2.20"
+"androidTestCore" = "1.7.0"
+"kotlinxCoroutines" = "1.10.2"
+"kotlinxSerialization" = "1.9.0"
+"ktor" = "3.3.1"
+"otp-java" = "2.1.0"
+"robolectric" = "4.16"
+
+[libraries]
+"androidx-test-core" = { module = "androidx.test:core", version.ref = "androidTestCore" }
+"kotlinx-coroutines" = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
+"kotlinx-serialization" = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
+"ktor-client-core" = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+"ktor-client-android" = { module = "io.ktor:ktor-client-android", version.ref = "ktor" }
+"ktor-client-darwin" = { module = "io.ktor:ktor-client-darwin-legacy", version.ref = "ktor" }
+"ktor-client-jvm" = { module = "io.ktor:ktor-client-java", version.ref = "ktor" }
+"ktor-client-js" = { module = "io.ktor:ktor-client-js", version.ref = "ktor" }
+"otp-java" = { module = "com.github.bastiaanjansen:otp-java", version.ref = "otp-java" }
+"robolectric" = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+
+[plugins]
+"definitions" = { id = "io.github.turansky.kfc.definitions", version.ref = "definitions" }
+"kotlin-serialization" = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+"npm-publishing" = { id = "org.danilopianini.npm.publish", version.ref = "npm-publishing" }
+"vault-client" = { id = "com.liftric.vault-client-plugin", version.ref = "vault-client" }
+"versioning" = { id = "net.nemerosa.versioning", version.ref = "versioning" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,35 +7,3 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
-
-dependencyResolutionManagement {
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    versionCatalogs {
-        create("libs") {
-            version("android-tools-gradle", "8.1.0")
-            version("kotlin", "1.9.10")
-            version("ktor", "2.3.5")
-
-            library("ktor-client-core", "io.ktor", "ktor-client-core").versionRef("ktor")
-            library("ktor-client-android", "io.ktor", "ktor-client-android").versionRef("ktor")
-            library("ktor-client-darwin", "io.ktor", "ktor-client-darwin-legacy").versionRef("ktor")
-            library("ktor-client-jvm", "io.ktor", "ktor-client-java").versionRef("ktor")
-            library("ktor-client-js", "io.ktor", "ktor-client-js").versionRef("ktor")
-            library("kotlinx-coroutines", "org.jetbrains.kotlinx", "kotlinx-coroutines-core").version("1.7.2")
-            library("kotlinx-serialization", "org.jetbrains.kotlinx", "kotlinx-serialization-json").version("1.5.1")
-            library("androidx-test-core", "androidx.test", "core").version("1.2.0")
-            library("roboelectric", "org.robolectric", "robolectric").version("4.9")
-            library("opt-java", "com.github.bastiaanjansen", "otp-java").version("1.3.2")
-
-            plugin("vault-client", "com.liftric.vault-client-plugin").version("2.0.0")
-            plugin("versioning", "net.nemerosa.versioning").version("3.0.0")
-            plugin("npm-publishing", "dev.petuska.npm.publish").version("3.0.0")
-            plugin("definitions", "io.github.turansky.kfc.definitions").version("5.50.0")
-            plugin("kotlin.serialization", "org.jetbrains.kotlin.plugin.serialization").versionRef("kotlin")
-        }
-    }
-}

--- a/src/androidUnitTest/kotlin/com/liftric/cognito/idp/IdentityProviderClientTests.kt
+++ b/src/androidUnitTest/kotlin/com/liftric/cognito/idp/IdentityProviderClientTests.kt
@@ -1,7 +1,7 @@
 package com.liftric.cognito.idp
 
 import com.bastiaanjansen.otp.HMACAlgorithm
-import com.bastiaanjansen.otp.TOTP
+import com.bastiaanjansen.otp.TOTPGenerator
 import kotlinx.coroutines.runBlocking
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -10,10 +10,12 @@ import java.time.Duration
 @RunWith(RobolectricTestRunner::class)
 actual class IdentityProviderClientTests: AbstractIdentityProviderClientTests() {
     override fun generateTotpCode(secret: String): String? {
-        val builder = TOTP.Builder(secret.toByteArray())
+        val builder = TOTPGenerator.Builder(secret.toByteArray())
         builder
-            .withPasswordLength(6)
-            .withAlgorithm(HMACAlgorithm.SHA1) // SHA256 and SHA512 are also supported
+            .withHOTPGenerator { hotpGenerator ->
+                hotpGenerator.withPasswordLength(6)
+                hotpGenerator.withAlgorithm(HMACAlgorithm.SHA1) // SHA256 and SHA512 are also supported
+            }
             .withPeriod(Duration.ofSeconds(30))
 
         val totp = builder.build()

--- a/src/commonMain/kotlin/com/liftric/cognito/idp/IdentityProviderClient.kt
+++ b/src/commonMain/kotlin/com/liftric/cognito/idp/IdentityProviderClient.kt
@@ -6,11 +6,8 @@ import io.ktor.client.call.*
 import io.ktor.client.engine.*
 import io.ktor.client.plugins.*
 import io.ktor.client.request.*
-import io.ktor.client.statement.*
 import io.ktor.http.*
 import kotlinx.serialization.SerializationException
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 /** Don't forget [IdentityProviderClientJS] when doing changes here :) */

--- a/src/commonTest/kotlin/com/liftric/cognito/idp/ResultTests.kt
+++ b/src/commonTest/kotlin/com/liftric/cognito/idp/ResultTests.kt
@@ -1,7 +1,7 @@
 package com.liftric.cognito.idp
 
 import com.liftric.cognito.idp.core.*
-import io.ktor.utils.io.errors.*
+import kotlinx.io.IOException
 import kotlin.test.*
 
 class ResultTests {

--- a/src/jsTest/kotlin/com/liftric/cognito/idp/IdentityProviderClientTests.kt
+++ b/src/jsTest/kotlin/com/liftric/cognito/idp/IdentityProviderClientTests.kt
@@ -5,6 +5,8 @@ import kotlinx.coroutines.promise
 
 actual class IdentityProviderClientTests : AbstractIdentityProviderClientTests()
 
-actual fun runTest(block: suspend () -> Unit): dynamic = MainScope().promise {
-    block.invoke()
+actual fun runTest(block: suspend () -> Unit): Unit {
+    MainScope().promise {
+        block.invoke()
+    }
 }

--- a/src/jvmTest/kotlin/com/liftric/cognito/idp/IdentityProviderClientTests.kt
+++ b/src/jvmTest/kotlin/com/liftric/cognito/idp/IdentityProviderClientTests.kt
@@ -1,8 +1,7 @@
 package com.liftric.cognito.idp
 
 import com.bastiaanjansen.otp.HMACAlgorithm
-import com.bastiaanjansen.otp.TOTP
-import io.ktor.utils.io.core.*
+import com.bastiaanjansen.otp.TOTPGenerator
 import kotlinx.coroutines.runBlocking
 import kotlin.text.toByteArray
 import java.time.Duration
@@ -10,10 +9,12 @@ import java.time.Duration
 
 actual class IdentityProviderClientTests: AbstractIdentityProviderClientTests() {
     override fun generateTotpCode(secret: String): String? {
-        val builder = TOTP.Builder(secret.toByteArray())
+        val builder = TOTPGenerator.Builder(secret.toByteArray())
         builder
-            .withPasswordLength(6)
-            .withAlgorithm(HMACAlgorithm.SHA1) // SHA256 and SHA512 are also supported
+            .withHOTPGenerator { hotpGenerator ->
+                hotpGenerator.withPasswordLength(6)
+                hotpGenerator.withAlgorithm(HMACAlgorithm.SHA1) // SHA256 and SHA512 are also supported
+            }
             .withPeriod(Duration.ofSeconds(30))
 
         val totp = builder.build()


### PR DESCRIPTION
This PR updates the dependencies of the cognito-idp library.

Gradle is updated to `9.1`. Ktor is upgraded to `3.3.1` with Kotlin being upgraded to version `2.2.20`. A version catalog is introduced to handle dependencies in a modern way. Other used dependencies are updated to their latest versions, spelling mistakes have been fixed with regard to dependency naming.

To appease changes in dependencies the minimum android sdk version is raised to `31` while `36` has been chosen as target. The Java target is raised to `17` to match the Java Http client of ktor.

The `build.gradle.kts` is updated with deprecations and outdated code being replaced. The `.gitignore` file is updated to ignore more build data.

I ran the jvm and android tests. The ios targets cannot be tested by me as I do not have access to a mac. 

The JS targets failed with the error `Cannot query the value of task ':compileKotlinJs' property 'outputFileProperty' because it has no value available`. Investigation showed that this happens when the kfc definitions plugin is used with Kotlin 2+. The documentation on the Kfc plugin is sparse but as it seems to only apply some default configuration for Kotlin/JS it is removed. With the plugin removed the JS target compiles again and the tests run through but we might have to revisit Kotlin/JS later on in case that the plugin applied configurations were needed in some way.
