### PR TITLE
feat: use vanniktech maven publish plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build testapp and test request (iOS)
         run: |
           cd iostests
-          xcodebuild clean test -project TestApp.xcodeproj -scheme TestApp -destination "platform=iOS Simulator,OS=26.0,name=iPhone 16" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO region=${{ secrets.region }} clientId=${{ secrets.clientid }}
+          xcodebuild clean test -project TestApp.xcodeproj -scheme TestApp -destination "platform=iOS Simulator,OS=26.0.1,name=iPhone 16" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO region=${{ secrets.region }} clientId=${{ secrets.clientid }}
       - name: Upload test result
         if: ${{ always() }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,9 +20,10 @@ jobs:
         run: ./gradlew versionDisplay
       - name: Publish Library
         env:
-          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
-          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
-          ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.OSSRH_USERNAME }}
-          ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.OSSRH_PASSWORD }}
           ORG_GRADLE_PROJECT_npmAccessKey: ${{ secrets.NPMJS_ACCESS_KEY }}
-        run: region=${{ secrets.region }} clientId=${{ secrets.clientid }} ./gradlew publishAllPublicationsToSonatypeRepository publishJsPackageToNpmjsRegistry
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
+        run: region=${{ secrets.region }} clientId=${{ secrets.clientid }} ./gradlew publishToMavenCentral
+#        run: region=${{ secrets.region }} clientId=${{ secrets.clientid }} ./gradlew publishToMavenCentral publishJsPackageToNpmjsRegistry

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - name: Set up JDK 21
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: 21
+          java-version: 17
           distribution: 'temurin'
       - name: Grant Permission to Execute
         run: chmod +x gradlew

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,5 +25,4 @@ jobs:
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
-        run: region=${{ secrets.region }} clientId=${{ secrets.clientid }} ./gradlew publishToMavenCentral
-#        run: region=${{ secrets.region }} clientId=${{ secrets.clientid }} ./gradlew publishToMavenCentral publishJsPackageToNpmjsRegistry
+        run: region=${{ secrets.region }} clientId=${{ secrets.clientid }} ./gradlew publishToMavenCentral publishJsPackageToNpmjsRegistry

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import com.android.build.gradle.LibraryExtension
 import com.liftric.vault.GetVaultSecretTask
+import com.vanniktech.maven.publish.KotlinMultiplatform
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeSimulatorTest
@@ -12,8 +13,46 @@ plugins {
     alias(libs.plugins.npm.publishing)
     alias(libs.plugins.versioning)
     alias(libs.plugins.vault.client)
-    id("maven-publish")
-    id("signing")
+    alias(libs.plugins.publish)
+}
+
+val actualVersion = with(versioning.info) {
+    if (branch == "HEAD" && dirty.not()) tag else full
+}
+
+mavenPublishing {
+    publishToMavenCentral()
+    signAllPublications()
+    configure(
+        KotlinMultiplatform(
+            sourcesJar = true,
+            androidVariantsToPublish = listOf("debug", "release"),
+        )
+    )
+
+    coordinates("com.liftric", "cognito-idp", actualVersion)
+    pom {
+        name.set(project.name)
+        description.set("Lightweight AWS Cognito Identity Provider client for Kotlin Multiplatform projects.")
+        url.set("https://github.com/liftric/cognito-idp")
+
+        licenses {
+            license {
+                name.set("MIT")
+                url.set("https://github.com/liftric/cognito-idp/blob/master/LICENSE")
+            }
+        }
+        developers {
+            developer {
+                id.set("liftric")
+                name.set("Liftric GmbH")
+                email.set("team@liftric.com")
+            }
+        }
+        scm {
+            url.set("https://github.com/liftric/cognito-idp")
+        }
+    }
 }
 
 repositories {
@@ -156,25 +195,10 @@ configure<LibraryExtension> {
     }
 
     namespace = "com.liftric.cognito.idp"
-
-    publishing {
-        multipleVariants {
-            allVariants()
-            withJavadocJar()
-        }
-    }
 }
 
 group = "com.liftric"
-version = with(versioning.info) {
-    if (branch == "HEAD" && dirty.not()) tag else full
-}
-
-afterEvaluate {
-    project.publishing.publications.withType(MavenPublication::class.java).forEach {
-        it.groupId = group.toString()
-    }
-}
+version = actualVersion
 
 tasks {
     withType(KotlinNativeSimulatorTest::class) {
@@ -260,56 +284,8 @@ tasks {
     }
 }
 
-val ossrhUsername: String? by project
-val ossrhPassword: String? by project
-
 val javadocJar by tasks.registering(Jar::class) {
     archiveClassifier.set("javadoc")
-}
-
-publishing {
-    repositories {
-        maven {
-            name = "sonatype"
-            setUrl("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
-            credentials {
-                username = ossrhUsername
-                password = ossrhPassword
-            }
-        }
-    }
-
-    publications.withType<MavenPublication> {
-        artifact(javadocJar.get())
-
-        pom {
-            name.set(project.name)
-            description.set("Lightweight AWS Cognito Identity Provider client for Kotlin Multiplatform projects.")
-            url.set("https://github.com/liftric/cognito-idp")
-
-            licenses {
-                license {
-                    name.set("MIT")
-                    url.set("https://github.com/liftric/cognito-idp/blob/master/LICENSE")
-                }
-            }
-            developers {
-                developer {
-                    id.set("benjohnde")
-                    name.set("Ben John")
-                    email.set("john@liftric.com")
-                }
-                developer {
-                    id.set("ingwersaft")
-                    name.set("Marcel Kesselring")
-                    email.set("kesselring@liftric.com")
-                }
-            }
-            scm {
-                url.set("https://github.com/liftric/cognito-idp")
-            }
-        }
-    }
 }
 
 val npmAccessKey: String? by project
@@ -347,13 +323,6 @@ npmPublish {
     }
 }
 
-signing {
-    val signingKey: String? by project
-    val signingPassword: String? by project
-    useInMemoryPgpKeys(signingKey, signingPassword)
-    sign(publishing.publications)
-}
-
 vault {
     vaultAddress.set("https://dark-lord.liftric.io")
     if (System.getenv("CI") == null) {
@@ -364,17 +333,11 @@ vault {
 }
 tasks {
     afterEvaluate {
-        val signingTasks = filter { it.name.startsWith("sign") }
         all {
             // lets bruteforce this until the plugins play along nicely again
 
             if (name.contains("compile", true) && name.contains("kotlin", true)) {
                 dependsOn("createJsEnvHack")
-            }
-            if (name.startsWith("publish")) {
-                signingTasks.forEach { signTask ->
-                    dependsOn(signTask)
-                }
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -138,7 +138,7 @@ kotlin {
 configure<LibraryExtension> {
     defaultConfig.apply {
         compileSdk = 36
-        minSdkVersion(31)
+        minSdkVersion(21)
         targetSdkVersion(36)
         testInstrumentationRunner = "org.robolectric.RobolectricTestRunner"
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@
 "npm-publishing" = "4.1.3"
 "vault-client" = "3.0.0"
 "versioning" = "3.1.0"
+"publish" = "0.34.0"
 # dependencies
 "android-tools-gradle" = "8.13.0"
 "kotlin" = "2.2.20"
@@ -30,3 +31,4 @@
 "npm-publishing" = { id = "org.danilopianini.npm.publish", version.ref = "npm-publishing" }
 "vault-client" = { id = "com.liftric.vault-client-plugin", version.ref = "vault-client" }
 "versioning" = { id = "net.nemerosa.versioning", version.ref = "versioning" }
+"publish" = { id = "com.vanniktech.maven.publish", version.ref = "publish" }


### PR DESCRIPTION
**MR Summary:** Updates CI, build configuration, and publishing setup for new Sonatype Maven Central Repository

**Changes include:**  
- **CI workflow update:**  
  - iOS simulator OS version updated from `26.0` → `26.0.1` in `ci.yml`.  
  - Publish workflow JDK downgraded from `21` → `17` in `publish.yml`.  

- **Android build configuration:**  
  - Lowered `minSdkVersion` from `31` → `21` in `build.gradle.kts`.  

- **Publishing & signing plugin migration:**  
  - Removed old `maven-publish` and `signing` setup.  
  - Integrated Vanniktech `maven-publish` plugin for Kotlin Multiplatform.  
  - Configured publishing to newer Sonatype Maven Central  
  - Updated `libs.versions.toml` to include new plugin

- **GitHub Actions publish workflow adjustments:**  
  - Updated environment variables to match Vanniktech plugin.  
  - Adjusted Gradle commands for publishing to new Maven Central.
